### PR TITLE
core: brand-neutral domain model + adapter interfaces

### DIFF
--- a/core/analysis.go
+++ b/core/analysis.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+// Analysis is the brand-agnostic result of DSP on a track: tempo, beat grid,
+// waveforms as per-band amplitude data, key, and detected cues. Each backend
+// encodes it to its own wire format — Pioneer PWV/ANLZ, Engine zlib BLOBs — so
+// the DSP runs once and the cache can store neutral data.
+type Analysis struct {
+	BPM      float64
+	Beats    []Beat // full beat grid
+	Detail   BandWaveform
+	Overview BandWaveform
+	Key      Key
+	Cues     []Cue
+	Phrases  []Phrase // song structure (intro/verse/chorus/…), optional
+}
+
+// Beat is one beat in the grid.
+type Beat struct {
+	TimeMs   float64
+	Downbeat bool // true on beat 1 of the bar
+}
+
+// BandWaveform is a waveform as per-point amplitude split across frequency
+// bands (bass/mid/treble), each 0..1. Backends map this onto their own colour-
+// waveform encodings; PointsPerSec records the sampling density.
+type BandWaveform struct {
+	PointsPerSec float64
+	Bass         []float32
+	Mid          []float32
+	Treble       []float32
+}
+
+// Phrase is a detected song-structure section.
+type Phrase struct {
+	StartMs float64
+	EndMs   float64
+	Kind    string // "intro", "verse", "chorus", "outro", …
+}

--- a/core/backend.go
+++ b/core/backend.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import (
+	"context"
+	"io"
+)
+
+// Source is the neutral data a Backend serves to players: the library, its
+// analysis, and the audio bytes. It is implemented once over the library +
+// analysis cache and consumed by every backend.
+type Source interface {
+	Track(TrackID) (*Track, bool)
+	Tracks() []*Track
+	Playlists() []*Playlist
+	Analysis(TrackID) (*Analysis, bool)
+	// Open returns the audio stream for a track and its size in bytes; the
+	// backend's file transport (NFS, HTTP) streams from it.
+	Open(TrackID) (io.ReadSeekCloser, int64, error)
+}
+
+// Backend is a live link/source protocol — Pro DJ Link, StageLinq, …. A process
+// may run several at once, so one library is visible to multiple ecosystems.
+type Backend interface {
+	// Name is a short identifier, e.g. "prolink" or "stagelinq".
+	Name() string
+	// Start announces on the network and serves src until ctx is cancelled.
+	Start(ctx context.Context, src Source) error
+	// Players and Mixers report the devices currently seen on the link.
+	Players() []PlayerState
+	Mixers() []MixerState
+	// Load asks a deck to load a track, where the protocol supports it.
+	Load(deck int, id TrackID) error
+	// Events streams player/mixer/beat changes for the UI and TUI.
+	Events() <-chan Event
+}

--- a/core/cue.go
+++ b/core/cue.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+// CueKind distinguishes a plain cue from a saved loop.
+type CueKind uint8
+
+const (
+	KindCue  CueKind = iota + 1 // a hot or memory cue
+	KindLoop                    // a saved loop (has an end)
+)
+
+// Cue is a hot cue, memory cue, or saved loop on a track. TimeMs is the start;
+// for a loop, LoopEndMs is the end.
+type Cue struct {
+	Number    uint16  `json:"number"` // 1-based hot-cue slot (A=1, B=2, …); 0 for memory cues
+	Kind      CueKind `json:"kind"`
+	TimeMs    uint32  `json:"time_ms"`
+	LoopEndMs uint32  `json:"loop_end_ms,omitempty"`
+	Color     uint32  `json:"color,omitempty"` // packed RGB or palette index
+	Comment   string  `json:"comment,omitempty"`
+}
+
+// Key is a musical key in both notations; a backend shows whichever its players
+// use (Camelot "8A" / standard "Am").
+type Key struct {
+	Camelot  string `json:"camelot"`
+	Standard string `json:"standard"`
+}

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package core is the brand-neutral heart of vynull: the domain model (tracks,
+// cues, playlists, analysis, player state) and the interfaces that pluggable
+// adapters implement — live link protocols (Backend/Source) and library file
+// formats (Importer/Exporter).
+//
+// Dependency rule: core imports nothing from analysis, link/*, format/*, or api;
+// everything else imports core. Keeping the model and contracts free of any one
+// ecosystem's wire formats (Pro DJ Link, StageLinq) or file formats (rekordbox,
+// Engine) makes a second protocol or library format an additive adapter rather
+// than a fork.
+//
+// Status: proposed foundation for the modular-backends refactor (see
+// docs/design/modular-backends.md). This package defines the target model;
+// concrete packages migrate onto it in later steps, so nothing imports it yet.
+package core

--- a/core/format.go
+++ b/core/format.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+// Library is a neutral snapshot of tracks and playlists — the currency of the
+// import/export adapters.
+type Library struct {
+	Tracks    []*Track
+	Playlists []*Playlist
+}
+
+// ImportOptions carries adapter-agnostic import knobs; a specific importer may
+// define its own richer options.
+type ImportOptions struct {
+	// RemapPath, when set, rewrites an imported absolute path onto a local file.
+	RemapPath func(string) string
+}
+
+// ExportOptions carries adapter-agnostic export knobs.
+type ExportOptions struct {
+	// CopyFiles copies audio into the destination instead of referencing it.
+	CopyFiles bool
+}
+
+// Importer reads a foreign library (rekordbox XML/master.db, Engine, Serato, …)
+// into the neutral model.
+type Importer interface {
+	Name() string
+	// Detect reports whether path looks like this format (a directory or file).
+	Detect(path string) bool
+	Import(path string, opts ImportOptions) (*Library, error)
+}
+
+// Exporter writes the neutral model out in a foreign format (rekordbox USB/PDB,
+// Engine Library, M3U, …).
+type Exporter interface {
+	Name() string
+	Export(lib *Library, dst string, opts ExportOptions) error
+}

--- a/core/player.go
+++ b/core/player.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import "time"
+
+// PlayerState is the live state of one deck on a link, as the UI and TUI show
+// it — brand-agnostic, so a CDJ and a Denon player look the same here.
+type PlayerState struct {
+	DeckID    int
+	Name      string  // "CDJ-3000", "Prime 4"
+	TrackID   TrackID // 0 if unknown/none
+	TrackName string
+	Artist    string
+	Key       string
+	BPM       float64
+	Pitch     float64 // tempo adjust as a fraction (+0.02 = +2%)
+	Playing   bool
+	OnAir     bool
+	Master    bool
+	BeatInBar int // 1..4, 0 if unknown
+	LastSeen  time.Time
+}
+
+// MixerState is the live state of a mixer on the link.
+type MixerState struct {
+	DeviceID     int
+	Name         string
+	MasterBPM    float64
+	MasterDevice int
+	BeatInBar    int
+	ChannelOnAir []bool
+	LastSeen     time.Time
+}
+
+// EventKind classifies a change a Backend pushes to the UI.
+type EventKind uint8
+
+const (
+	EventPlayer EventKind = iota // a player's state changed
+	EventMixer                   // a mixer's state changed
+	EventBeat                    // a beat tick
+	EventPeer                    // a device joined or left
+)
+
+// Event is a change a Backend streams to the UI/TUI via Backend.Events.
+type Event struct {
+	Kind   EventKind
+	DeckID int
+	Player *PlayerState
+	Mixer  *MixerState
+}

--- a/core/track.go
+++ b/core/track.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package core
+
+import "time"
+
+// TrackID identifies a track within a Library for the life of the process.
+// Backends map it onto their own on-wire identifiers.
+type TrackID uint32
+
+// DurationSec is a track length in whole seconds.
+type DurationSec uint32
+
+// Track is one library entry: brand-agnostic metadata plus the beat-grid
+// override fields the UI can edit. Format encoders (ANLZ/PDB, Engine) map it
+// onto their own representations. The field set mirrors what vynull already
+// tracks so existing packages can migrate onto this type.
+type Track struct {
+	ID       TrackID     `json:"id"`
+	Title    string      `json:"title"`
+	Artist   string      `json:"artist"`
+	Album    string      `json:"album"`
+	Genre    string      `json:"genre"`
+	Duration DurationSec `json:"duration"`
+	BPM      float64     `json:"bpm"`
+	Key      string      `json:"key"` // display key; Analysis carries both notations
+	Rating   uint8       `json:"rating"`
+	Year     int         `json:"year"`
+	TrackNum int         `json:"track_num"`
+	DiscNum  int         `json:"disc_num"`
+
+	FilePath string `json:"file_path"` // absolute path on disk
+	FileType string `json:"file_type"` // "mp3", "m4a", "flac", "wav", "aiff"
+	FileSize int64  `json:"file_size"`
+	ArtID    uint32 `json:"art_id"` // artwork lookup ID, 0 if none
+
+	Comment        string `json:"comment"`
+	Label          string `json:"label"`
+	OriginalArtist string `json:"original_artist"`
+	Remixer        string `json:"remixer"`
+	MixName        string `json:"mix_name"`
+
+	DateAdded   time.Time `json:"date_added"`
+	Bitrate     int       `json:"bitrate"`      // kbps
+	SampleRate  int       `json:"sample_rate"`  // Hz
+	SampleDepth int       `json:"sample_depth"` // bits
+	PlayCount   int       `json:"play_count"`
+	ColorID     uint8     `json:"color_id"`
+
+	FileMissing bool `json:"file_missing,omitempty"`
+
+	// Beat-grid overrides. DetectedBPM snapshots the auto-detected value;
+	// BPM (above) is the effective value used downstream. BeatPhaseShift
+	// rotates which detected beat is the downbeat (0 = detector's choice).
+	DetectedBPM    float64 `json:"detected_bpm,omitempty"`
+	BeatPhaseShift int     `json:"beat_phase_shift,omitempty"`
+}
+
+// Playlist is an ordered list of tracks, or a folder of child playlists. A
+// smart playlist evaluates rules at read time; the rules are opaque here and a
+// format adapter interprets them.
+type Playlist struct {
+	ID       uint32    `json:"id"`
+	Name     string    `json:"name"`
+	ParentID uint32    `json:"parent_id"` // 0 = root
+	IsFolder bool      `json:"is_folder"`
+	IsSmart  bool      `json:"is_smart"`
+	TrackIDs []TrackID `json:"track_ids,omitempty"`
+}

--- a/docs/design/modular-backends.md
+++ b/docs/design/modular-backends.md
@@ -1,0 +1,111 @@
+# Modular backends: a brand-neutral core
+
+- **Status:** Proposed
+- **Scope:** architecture / refactor
+
+## Goal
+
+Serve multiple live link protocols (Pro DJ Link today, Denon StageLinq/EAAS
+next) and read/write multiple library formats (rekordbox today; Engine, Serato,
+Traktor next) from **one brand-neutral core**. Everything on the wire or in a
+file becomes a pluggable adapter, not a fork.
+
+## Package layout
+
+```
+core/                   neutral domain + interfaces (no wire, no file formats, no DSP)
+  track.go              Track, Playlist, TrackID, DurationSec
+  cue.go                Cue, CueKind, Key
+  analysis.go           Analysis, Beat, BandWaveform  — DSP *results*, brand-agnostic
+  player.go             PlayerState, MixerState, Event
+  backend.go            Backend, Source interfaces
+  format.go             Library, Importer, Exporter interfaces
+
+analysis/               PURE DSP → produces core.Analysis (no PWV/ANLZ/PDB)
+  bpm.go beatgrid.go key.go waveform.go onset.go cues.go ...
+
+link/                   live protocol backends (each implements core.Backend)
+  prolink/              Pro DJ Link — today's stack, regrouped
+    device.go           VirtualDevice: claim / announce / keepalive / status   (was device/)
+    dbserver/           TCP menu / query server                                (was dbserver/)
+    nfs/                NFS file transport                                      (was nfs/)
+    anlz/               ANLZ / PWV4 / PWV5 / PQT / PVB encoders (core.Analysis → bytes)
+    pdb/                export.pdb writer                                       (was pdb/)
+    proto/              packet structs                                          (was proto/)
+  stagelinq/            Denon — future
+    device.go           StageLinq discovery + StateMap + BeatInfo (via go-stagelinq)
+    eaas/               EAAS library server + HTTP audio transport
+    engine/             Engine Library SQLite writer + zlib/qCompress BLOB codecs
+
+format/                 library import/export (each implements core.Importer / Exporter)
+  rekordbox/            XML, master.db, backup .zip (in) + PDB / USB (out)  — reuses link/prolink/{pdb,anlz}
+  engine/  (future)     Engine Library SQLite                              — reuses link/stagelinq/engine
+  serato/ traktor/ m3u/ (future)
+
+api/                    HTTP + web UI + stores (cue/tag/playlist/menu) — depends on core only
+cmd/ (or main.go)       wiring: choose backend(s) + importers/exporters, inject into api + TUI
+```
+
+**Dependency rule**
+- `core` imports nothing from `analysis` / `link` / `format` / `api`. Everyone imports `core`.
+- `api` and the TUI import `core` **only** — never a concrete backend.
+- Pioneer codecs (`anlz`, `pdb`) live under `link/prolink` and are shared by
+  `format/rekordbox` (rekordbox files *are* Pioneer's format). Same pattern for Engine.
+
+## Core interfaces
+
+```go
+// Source = the neutral data a Backend serves TO players.
+type Source interface {
+    Track(TrackID) (*Track, bool)
+    Tracks() []*Track
+    Playlists() []*Playlist
+    Analysis(TrackID) (*Analysis, bool)              // beatgrid, waveforms, cues, key
+    Open(TrackID) (io.ReadSeekCloser, int64, error)  // audio bytes; transport streams this
+}
+
+// Backend = a pluggable live link/source protocol.
+type Backend interface {
+    Name() string                                  // "prolink" | "stagelinq"
+    Start(ctx context.Context, src Source) error   // announce + serve until ctx cancels
+    Players() []PlayerState
+    Mixers()  []MixerState
+    Load(deck int, id TrackID) error
+    Events() <-chan Event                           // player/beat/state changes for UI + TUI
+}
+```
+
+`Analysis` is brand-agnostic; each backend **encodes** it to its own wire format
+(Pioneer PWV/ANLZ vs Engine zlib BLOB). Same idea for `Importer`/`Exporter`.
+
+## The one genuine refactor
+
+Today `analysis.Result` mixes DSP results with Pioneer-encoded blobs
+(`WaveDetail` PWV5, `BeatGridPQT2`, `SongStructure` PSSI, …). Split it:
+
+- Keep the DSP (BPM, beatgrid, key, waveform band-data, cues) in `analysis`,
+  returning `core.Analysis`.
+- Move the encoders (`anlz.go`, `pqt2.go`, `pvb2.go`, `render.go`, PWV packers)
+  to `link/prolink/anlz`, taking `core.Analysis` → bytes.
+- The analysis cache stores neutral `core.Analysis`; each backend encodes on demand.
+
+Then decouple `api` from its thin Pioneer surface (it only touches `device` for
+settings/VirtualDevice and `dbserver` for cues): move cues into `core`, put CDJ
+settings behind a `core.Settings` interface (no-op for StageLinq), and `api`
+imports `core` only.
+
+## Migration order (each a shippable PR; 1–4 are pure refactors)
+
+1. **Introduce `core`** with the model types + interfaces (this doc's PR). Purely
+   additive — nothing imports it yet, zero behavior change.
+2. **Split `analysis`** into DSP (→ `core.Analysis`) vs encoders (→ `anlz`).
+   Highest-value cleanup; unblocks everything.
+3. **Move `proto/device/dbserver/nfs/pdb` under `link/prolink`**, define + implement `core.Backend`.
+4. **Decouple `api`** from `device`/`dbserver` via `core` interfaces.
+5. **Extract `format/rekordbox`** behind `Importer`/`Exporter`.
+6. `stagelinq` spike + `format/engine` slot in with no core changes.
+
+Steps 1–4 are pure refactors — no new features, fully testable against current
+hardware — and leave the code cleaner even if a second protocol never ships.
+Running two backends at once means the library appears to CDJs *and* Denon
+players simultaneously.


### PR DESCRIPTION
## Summary

First step of the **modular-backends** refactor (design doc included). It adds a
brand-neutral `core` package — the domain model plus the interfaces that
pluggable adapters will implement — so vynull can eventually serve multiple live
link protocols (Pro DJ Link today, Denon StageLinq/EAAS next) and read/write
multiple library formats (rekordbox today; Engine, Serato, …) from **one core**
instead of forking the codebase per ecosystem.

**Purely additive: nothing imports `core` yet, so there is no behavior change.**
`main` builds and runs exactly as before — this only lays the foundation.

## What's in it

**`docs/design/modular-backends.md`** — the architecture proposal / ADR: goals,
target package layout, the `Backend`/`Source`/`Importer`/`Exporter` interfaces,
the one genuine refactor ahead (splitting `analysis` DSP from the Pioneer
encoders), and a staged migration order.

**`core/`** — the neutral package (standard-library only):

- **Model:** `Track`, `Playlist`, `Cue`/`CueKind`, `Key`,
  `Analysis`/`Beat`/`BandWaveform`/`Phrase`,
  `PlayerState`/`MixerState`/`Event`, `TrackID`.
- **Interfaces:**
  - `Source` — the neutral data a backend serves to players (tracks, playlists,
    analysis, audio bytes).
  - `Backend` — a live link protocol: discover/announce/serve, report live
    player + mixer state, load a track onto a deck.
  - `Importer` / `Exporter` — library file-format adapters.

## Design notes

- **Dependency rule:** `core` imports nothing from `analysis` / `link` /
  `format` / `api`; everything else imports `core`. This keeps the model and
  contracts free of any single ecosystem's wire formats (Pro DJ Link, StageLinq)
  or file formats (rekordbox, Engine).
- **Migration-friendly shapes:** `Track` (with JSON tags), `Cue`, and
  `PlayerState` mirror the existing `library.Track` / `dbserver.CuePoint` /
  `device.PlayerState`, so the later refactor steps map onto them cleanly.
- `Analysis` is brand-agnostic (per-band waveform amplitudes, beat grid, key,
  cues); each backend will **encode** it to its own wire format — Pioneer
  PWV/ANLZ, Engine zlib BLOBs.

## Verification

- `go build ./...` ✅
- `go vet ./core/` ✅
- `gofmt -l core/` clean ✅
- Grep confirms **nothing imports `core`** → additive, zero behavior change ✅

## Part of a series (merge order matters)

This is **step 1**. **Step 2** (`analysis-split`, stacked on this branch) makes
`analysis` produce `core.Analysis` and extracts the neutral band waveforms.
**Merge this PR first** — `analysis-split` won't build without `core`.

## Where to look

Start with `docs/design/modular-backends.md` for the whole plan, then skim
`core/backend.go` (`Source` / `Backend`) and `core/format.go`
(`Importer` / `Exporter`) — those interfaces are the contract everything else
will hang off.
