### PR TITLE
analysis: produce neutral core.Analysis + lock the waveform encoders (modular-backends step 2)

### DIFF
--- a/analysis/bandwaveform.go
+++ b/analysis/bandwaveform.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package analysis
+
+import "github.com/vynulldev/vynull/core"
+
+// Neutral waveform resolutions. Detail matches the PWV5 detail rate; overview
+// is a fixed coarse width (like the PWV4 overview) whose points-per-second
+// therefore varies with track length.
+const overviewPoints = 1200
+
+// BandWaveformDetail extracts the brand-neutral per-band (bass/mid/treble)
+// amplitude envelope of a track at the detail resolution (detailEntriesPerSec).
+// This is the shareable DSP output every backend re-encodes into its own colour
+// waveform (Pioneer PWV5, Engine high-res, …); it reuses the same band split as
+// GenerateDetail so the two agree.
+func BandWaveformDetail(samples []float32, sampleRate int) core.BandWaveform {
+	durationSec := float64(len(samples)) / float64(sampleRate)
+	numPoints := int(durationSec * detailEntriesPerSec)
+	if numPoints < 1 {
+		numPoints = 1
+	}
+	bass, mid, treble, _ := splitBandsAndPeaks(samples, sampleRate, numPoints)
+	return bandsToWaveform(detailEntriesPerSec, bass, mid, treble)
+}
+
+// BandWaveformOverview extracts the neutral per-band envelope at a fixed coarse
+// width (overviewPoints), for whole-track overview rendering.
+func BandWaveformOverview(samples []float32, sampleRate int) core.BandWaveform {
+	durationSec := float64(len(samples)) / float64(sampleRate)
+	if durationSec <= 0 {
+		return core.BandWaveform{}
+	}
+	bass, mid, treble, _ := splitBandsAndPeaks(samples, sampleRate, overviewPoints)
+	return bandsToWaveform(float64(overviewPoints)/durationSec, bass, mid, treble)
+}
+
+// bandsToWaveform normalises per-point peak amplitudes to a neutral 0..1
+// BandWaveform, dividing every band by the single loudest band-point so the
+// relative energy between the bands is preserved.
+func bandsToWaveform(pointsPerSec float64, bass, mid, treble []float64) core.BandWaveform {
+	max := 0.0
+	for _, s := range [][]float64{bass, mid, treble} {
+		for _, v := range s {
+			if v > max {
+				max = v
+			}
+		}
+	}
+	inv := 0.0
+	if max > 0 {
+		inv = 1.0 / max
+	}
+	scale := func(src []float64) []float32 {
+		dst := make([]float32, len(src))
+		for i, v := range src {
+			dst[i] = float32(v * inv)
+		}
+		return dst
+	}
+	return core.BandWaveform{
+		PointsPerSec: pointsPerSec,
+		Bass:         scale(bass),
+		Mid:          scale(mid),
+		Treble:       scale(treble),
+	}
+}
+
+// CoreWithBands returns the full neutral analysis: the Result's DSP facts (via
+// Core) plus the detail and overview band waveforms extracted from samples.
+// The caller supplies samples because they aren't kept in the cached Result —
+// keeping the (large) band arrays out of the on-disk cache.
+func (r *Result) CoreWithBands(samples []float32, sampleRate int) *core.Analysis {
+	a := r.Core()
+	a.Detail = BandWaveformDetail(samples, sampleRate)
+	a.Overview = BandWaveformOverview(samples, sampleRate)
+	return a
+}

--- a/analysis/bandwaveform_test.go
+++ b/analysis/bandwaveform_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package analysis
+
+import "testing"
+
+func TestBandWaveformDetail(t *testing.T) {
+	samples := synthSine(100, 2.0, 0.5) // 2s bass tone
+	w := BandWaveformDetail(samples, analysisRate)
+
+	if w.PointsPerSec != detailEntriesPerSec {
+		t.Errorf("PointsPerSec = %v, want %v", w.PointsPerSec, float64(detailEntriesPerSec))
+	}
+	want := int(2.0 * detailEntriesPerSec)
+	if len(w.Bass) != want || len(w.Mid) != want || len(w.Treble) != want {
+		t.Fatalf("point counts: bass=%d mid=%d treble=%d want=%d", len(w.Bass), len(w.Mid), len(w.Treble), want)
+	}
+
+	// Every value in [0,1], and the loudest band-point normalises to ~1.
+	var peak float32
+	for i := range w.Bass {
+		for _, v := range []float32{w.Bass[i], w.Mid[i], w.Treble[i]} {
+			if v < 0 || v > 1.0001 {
+				t.Fatalf("value out of range: %v", v)
+			}
+			if v > peak {
+				peak = v
+			}
+		}
+	}
+	if peak < 0.99 {
+		t.Errorf("expected a normalised peak near 1.0, got %v", peak)
+	}
+
+	// A 100 Hz tone is bass-dominant mid-track.
+	m := want / 2
+	if w.Bass[m] <= w.Treble[m] {
+		t.Errorf("100Hz tone should be bass-dominant: bass=%v treble=%v", w.Bass[m], w.Treble[m])
+	}
+}
+
+func TestBandWaveformOverview(t *testing.T) {
+	w := BandWaveformOverview(synthSine(100, 2.0, 0.5), analysisRate)
+	if len(w.Bass) != overviewPoints {
+		t.Errorf("overview points = %d, want %d", len(w.Bass), overviewPoints)
+	}
+	if w.PointsPerSec != float64(overviewPoints)/2.0 {
+		t.Errorf("PointsPerSec = %v, want %v", w.PointsPerSec, float64(overviewPoints)/2.0)
+	}
+}
+
+func TestCoreWithBands(t *testing.T) {
+	samples := synthSine(100, 2.0, 0.5)
+	r := &Result{BPM: 120, KeyCamelot: "8A", KeyStandard: "Am"}
+	a := r.CoreWithBands(samples, analysisRate)
+	if a.BPM != 120 {
+		t.Errorf("BPM = %v, want 120", a.BPM)
+	}
+	if len(a.Detail.Bass) == 0 || len(a.Overview.Bass) == 0 {
+		t.Errorf("expected detail + overview band data, got detail=%d overview=%d",
+			len(a.Detail.Bass), len(a.Overview.Bass))
+	}
+}

--- a/analysis/tocore.go
+++ b/analysis/tocore.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package analysis
+
+import "github.com/vynulldev/vynull/core"
+
+// phraseKindName maps the mood_high_phrase enum to the neutral labels used in
+// core.Analysis (mirrors the API's phrase naming in api/api.go).
+var phraseKindName = map[uint16]string{
+	1: "intro", 2: "up", 3: "down", 5: "chorus", 6: "outro",
+}
+
+// Core projects the Pioneer-flavoured Result onto the brand-neutral
+// core.Analysis — the DSP facts (tempo, beat grid, key, song structure) a
+// backend re-encodes into its own wire format.
+//
+// Step 2 of the modular-backends refactor (docs/design/modular-backends.md):
+// this is the DSP→neutral half. Waveform band data (core.BandWaveform) and cues
+// are not carried yet; they arrive with the encoder split, when the PWV/ANLZ
+// packers move out of this package and consume core.Analysis instead of raw
+// samples.
+func (r *Result) Core() *core.Analysis {
+	a := &core.Analysis{
+		BPM: r.BPM,
+		Key: core.Key{Camelot: r.KeyCamelot, Standard: r.KeyStandard},
+	}
+	if len(r.Beats) > 0 {
+		a.Beats = make([]core.Beat, len(r.Beats))
+		for i, ms := range r.Beats {
+			// Beats are labelled 1..4 repeating; DownbeatIndex marks the first
+			// beat 1. Fold the offset into [0,4) so beats before it classify too.
+			a.Beats[i] = core.Beat{
+				TimeMs:   ms,
+				Downbeat: ((i-r.DownbeatIndex)%4+4)%4 == 0,
+			}
+		}
+	}
+	for _, p := range r.Phrases {
+		a.Phrases = append(a.Phrases, core.Phrase{
+			StartMs: p.StartMs,
+			EndMs:   p.EndMs,
+			Kind:    phraseKindName[p.Kind],
+		})
+	}
+	return a
+}

--- a/analysis/tocore_test.go
+++ b/analysis/tocore_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package analysis
+
+import "testing"
+
+func TestResultCore(t *testing.T) {
+	r := &Result{
+		BPM:           128,
+		KeyCamelot:    "8A",
+		KeyStandard:   "Am",
+		Beats:         []float64{0, 500, 1000, 1500, 2000},
+		DownbeatIndex: 0, // beats 0 and 4 are downbeats (every 4th)
+		Phrases: []Phrase{
+			{Kind: 1, StartMs: 0, EndMs: 1000},
+			{Kind: 5, StartMs: 1000, EndMs: 2000},
+		},
+	}
+	a := r.Core()
+
+	if a.BPM != 128 {
+		t.Errorf("BPM = %v, want 128", a.BPM)
+	}
+	if a.Key.Camelot != "8A" || a.Key.Standard != "Am" {
+		t.Errorf("Key = %+v, want {8A Am}", a.Key)
+	}
+	if len(a.Beats) != 5 {
+		t.Fatalf("len(Beats) = %d, want 5", len(a.Beats))
+	}
+	if !a.Beats[0].Downbeat || !a.Beats[4].Downbeat || a.Beats[1].Downbeat {
+		t.Errorf("downbeat flags wrong: %+v", a.Beats)
+	}
+	if a.Beats[2].TimeMs != 1000 {
+		t.Errorf("Beats[2].TimeMs = %v, want 1000", a.Beats[2].TimeMs)
+	}
+	if len(a.Phrases) != 2 || a.Phrases[0].Kind != "intro" || a.Phrases[1].Kind != "chorus" {
+		t.Errorf("Phrases = %+v, want intro/chorus", a.Phrases)
+	}
+}

--- a/analysis/waveform_golden_test.go
+++ b/analysis/waveform_golden_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package analysis
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math"
+	"testing"
+)
+
+// goldenSignal is the deterministic 3-second bass+mid+treble tone used to lock
+// the colour-waveform encoders byte-for-byte. math.Sin is bit-stable in Go, so
+// the output hashes are reproducible across machines. (Matches the signal in
+// TestPWV5GoldenHash.)
+func goldenSignal() []float32 {
+	n := analysisRate * 3
+	s := make([]float32, n)
+	for i := 0; i < n; i++ {
+		t := float64(i) / float64(analysisRate)
+		s[i] = float32(
+			0.6*math.Sin(2*math.Pi*200*t) +
+				0.3*math.Sin(2*math.Pi*2000*t) +
+				0.15*math.Sin(2*math.Pi*8000*t),
+		)
+	}
+	return s
+}
+
+// checkGolden hashes an encoder's output and compares it to want. These guard
+// the wire bytes CDJs render from, so the encoders can be moved/refactored (the
+// modular-backends split) without silently changing what a deck displays.
+//
+// To (re)seed after an intentional encoder change: run
+//
+//	go test ./analysis -run GoldenHash -v
+//
+// and paste the printed hash into the matching want.
+func checkGolden(t *testing.T, name string, out []byte, want string) {
+	t.Helper()
+	sum := sha256.Sum256(out)
+	got := hex.EncodeToString(sum[:])
+	if got != want {
+		t.Errorf("%s encoder output changed.\n  got:  %s\n  want: %s\n"+
+			"If intentional, update the want constant.", name, got, want)
+	}
+}
+
+func TestPWV4GoldenHash(t *testing.T) { // color overview preview
+	checkGolden(t, "PWV4 (colour preview)",
+		GenerateColorPreview(goldenSignal(), analysisRate),
+		"44bce394255ddcf45e1df0f0b978ada68c665fe645d5bfbd9c6019c05130f5bb")
+}
+
+func TestPWV6GoldenHash(t *testing.T) { // 3-band overview preview
+	checkGolden(t, "PWV6 (3-band preview)",
+		GeneratePreview3Band(goldenSignal(), analysisRate),
+		"26994eff66433fca98c0b6a3685c8739aa489bb09214be21b0a8279046bc3f59")
+}
+
+func TestPWV7GoldenHash(t *testing.T) { // 3-band detail
+	checkGolden(t, "PWV7 (3-band detail)",
+		GenerateDetail3Band(goldenSignal(), analysisRate),
+		"5cbfe40515092522a120d8b03aaa80ed9deb07b3ae7cada41bc28d1cddb409c0")
+}

--- a/analysis/waveform_golden_test.go
+++ b/analysis/waveform_golden_test.go
@@ -52,6 +52,15 @@ func TestPWV4GoldenHash(t *testing.T) { // color overview preview
 		"44bce394255ddcf45e1df0f0b978ada68c665fe645d5bfbd9c6019c05130f5bb")
 }
 
+// PWV5 is the served detail scrolling waveform. If this hash changes on an
+// intentional encoder tweak, also bump cacheVersion in analysis.go so existing
+// caches re-analyze.
+func TestPWV5GoldenHash(t *testing.T) { // detail scrolling waveform
+	checkGolden(t, "PWV5 (detail)",
+		GenerateDetail(goldenSignal(), analysisRate),
+		"053db4c3aa8762da39e4757f1309d9c379b92aae343cab2261a482287dd5ab20")
+}
+
 func TestPWV6GoldenHash(t *testing.T) { // 3-band overview preview
 	checkGolden(t, "PWV6 (3-band preview)",
 		GeneratePreview3Band(goldenSignal(), analysisRate),

--- a/analysis/waveform_test.go
+++ b/analysis/waveform_test.go
@@ -3,8 +3,6 @@
 package analysis
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"math"
 	"testing"
 )
@@ -119,39 +117,5 @@ func TestPWV5ClassicDominantBand(t *testing.T) {
 				t.Fatalf("%d/%d entries did not have %s dominant", mismatched, checked, c.dominant)
 			}
 		})
-	}
-}
-
-// TestPWV5GoldenHash locks the wire format against a deterministic synth
-// signal. If GenerateDetail's output changes byte-for-byte (filter tweaks,
-// formula tweaks, bit-layout changes), this fails — at which point you must
-// bump cacheVersion in analysis.go and update the constant below.
-func TestPWV5GoldenHash(t *testing.T) {
-	// 3-second mixed-band signal: bass + mid + treble at differing amplitudes,
-	// deterministic across machines (math.Sin is bit-stable in Go).
-	n := analysisRate * 3
-	samples := make([]float32, n)
-	for i := 0; i < n; i++ {
-		t := float64(i) / float64(analysisRate)
-		samples[i] = float32(
-			0.6*math.Sin(2*math.Pi*200*t) +
-				0.3*math.Sin(2*math.Pi*2000*t) +
-				0.15*math.Sin(2*math.Pi*8000*t),
-		)
-	}
-
-	out := GenerateDetail(samples, analysisRate)
-	sum := sha256.Sum256(out)
-	got := hex.EncodeToString(sum[:])
-
-	// To update: run `go test ./analysis -run TestPWV5GoldenHash -v`
-	// then paste the printed hash here. (Bumping cacheVersion is optional and
-	// intentionally skipped for the band-crossover change so imported
-	// rekordbox waveforms in existing caches aren't discarded; new/
-	// re-analyzed tracks pick up the calibrated colours.)
-	const want = "053db4c3aa8762da39e4757f1309d9c379b92aae343cab2261a482287dd5ab20"
-	if got != want {
-		t.Fatalf("PWV5 classic encoder output changed.\n  got:  %s\n  want: %s\nIf this change is intentional, bump cacheVersion in analysis.go and update the want constant.",
-			got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Step 2 of the **modular-backends** refactor: the **DSP → neutral** half. `analysis`
now produces the brand-agnostic `core.Analysis` (tempo, beat grid, key, phrases,
and per-band waveforms), so a future backend can consume analysis without any
Pioneer types. It also lands golden-hash tests over all four colour-waveform
encoders as the safety net for the byte-sensitive encoder relocation still to
come (step 2, part 3).

**Additive and byte-safe.** No encoder logic or serving-path code changes — the
PWV4/5/6/7 outputs are byte-for-byte identical (proven by the golden tests), so
CDJs render exactly as before.

## What's in it

**Part 1 — `Result.Core()`** (`analysis/tocore.go`): projects the Pioneer-flavoured
`analysis.Result` onto `core.Analysis` — BPM, beat grid (with downbeat flags
derived from `DownbeatIndex`), key (both notations), and phrases (reusing the
API's phrase-name mapping). `analysis` now depends on `core`.

**Part 2 — band-waveform extraction** (`analysis/bandwaveform.go`):
`BandWaveformDetail` / `BandWaveformOverview` turn samples into the neutral
bass/mid/treble amplitude envelope (0..1, inter-band energy preserved), reusing
`GenerateDetail`'s own band split (`splitBandsAndPeaks`) so the neutral data
agrees with the PWV5 output. `Result.CoreWithBands(samples, sr)` assembles the
full `core.Analysis`; samples are passed in rather than cached, keeping the large
float arrays off disk.

**Golden safety net** (`analysis/waveform_golden_test.go`): new byte-for-byte
tests for **PWV4** (`GenerateColorPreview`), **PWV6** (`GeneratePreview3Band`),
and **PWV7** (`GenerateDetail3Band`), and the existing **PWV5** test moved in
beside them to share the `goldenSignal()` / `checkGolden()` helpers (its hash is
unchanged). All four colour waveforms are now locked.

## Why now (and what's deliberately *not* here)

The remaining half of step 2 — **relocating the PWV/ANLZ/PQT/PVB/PSSI encoders
into `link/prolink/anlz` to consume `core.Analysis`, then repointing
`dbserver`/`api`/`proto`** — changes the wire-serving path and is best done as
its own PR. The golden tests in this PR are the guardrail for that move: a
single changed byte will fail them. (PWV5 has always been guarded; this adds
PWV4/6/7.) Even so, that later PR should get a **real-CDJ smoke test**, since the
golden tests lock the *current* bytes but can't confirm a deck renders them
end-to-end.

## Verification

- `go build ./...` ✅ · `go vet ./analysis/` ✅ · `gofmt` clean ✅
- New tests pass: `TestResultCore`, `TestBandWaveformDetail/Overview`,
  `TestCoreWithBands`, `TestPWV4/5/6/7GoldenHash` (deterministic, `-count=2`) ✅
- `TestPWV5GoldenHash` unchanged → encoders byte-identical, additive ✅

## Where to look

`analysis/tocore.go` and `analysis/bandwaveform.go` are the whole production
surface; `analysis/waveform_golden_test.go` shows the encoder guardrails. Nothing
in the serving path (`dbserver`, `api`, `proto`) is touched.
