### PR TITLE
library: import Traktor collection.nml (tracks, playlists, cues)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -899,6 +899,10 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 		if incTracks {
 			result, playlists, tags, colors, err = library.ImportRekordboxXML(s.Library, req.Path)
 		}
+	case ".nml":
+		if incTracks {
+			result, playlists, tags, colors, masterCues, err = library.ImportTraktorNML(s.Library, req.Path)
+		}
 	case ".db":
 		// The master.db is SQLCipher-encrypted; the user supplies the 64-hex
 		// key (the import dialog collects it). We ship no key and don't extract
@@ -970,7 +974,7 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 			result, playlists, tags, colors, assets, masterCues, err = library.ImportRekordboxMasterDB(s.Library, dbPath, key)
 		}
 	default:
-		http.Error(w, "path must be a .xml, .db, or .zip (rekordbox backup) file", http.StatusBadRequest)
+		http.Error(w, "path must be a .xml, .nml (Traktor), .db, or .zip (rekordbox backup) file", http.StatusBadRequest)
 		return
 	}
 

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -6117,8 +6117,8 @@ function renderLibrary(tracks) {
         <button type="button" id="lib-empty-add" class="source-btn">+ Add tracks or folders</button>
         <div class="lib-empty-sub">MP3 · M4A · FLAC · WAV · AIFF</div>
         <div class="lib-empty-or">or</div>
-        <button type="button" id="lib-empty-import" class="source-btn">↓ Import your rekordbox library</button>
-        <div class="lib-empty-sub">XML · master.db · backup .zip</div>
+        <button type="button" id="lib-empty-import" class="source-btn">↓ Import your library</button>
+        <div class="lib-empty-sub">rekordbox · Traktor</div>
       </div>`;
       const b = document.getElementById('lib-empty-import');
       if (b) b.onclick = () => openImportRekordboxDialog();
@@ -6947,8 +6947,8 @@ function renderSettings(cfg) {
           <div id="add-path-status" class="export-hint" style="display:none; margin-top:8px;"></div>
         </div>
         <div class="source-action">
-          <button type="button" id="set-import-rb" class="source-btn">↓ Import from rekordbox…</button>
-          <div class="export-hint">Bring in tracks, playlists, tags, cues, and analysis from a rekordbox <b>XML</b> export, an encrypted <b>master.db</b>, or a library backup <b>.zip</b>.</div>
+          <button type="button" id="set-import-rb" class="source-btn">↓ Import a library…</button>
+          <div class="export-hint">Bring in tracks, playlists, tags, cues, and analysis from a rekordbox <b>XML</b> export, an encrypted <b>master.db</b>, or a library backup <b>.zip</b> — or a Traktor <b>collection.nml</b>.</div>
         </div>
         <div class="source-action">
           <button type="button" id="set-fix-paths" class="source-btn">↪ Fix track paths…</button>
@@ -10738,7 +10738,7 @@ function openImportRekordboxDialog() {
   m.className = 'menu-modal show';
   m.innerHTML = `
     <div class="head">
-      <span>IMPORT REKORDBOX LIBRARY</span>
+      <span>IMPORT LIBRARY</span>
       <button class="x" type="button" title="Close">×</button>
     </div>
     <div class="body">
@@ -10758,7 +10758,9 @@ function openImportRekordboxDialog() {
           waveforms, beat grids, cover art, and player/mixer settings sitting beside it;
           a master.db copied out on its own brings metadata + cues only. A
           <b>library backup .zip</b> (rekordbox's <b>File → Library → Backup</b>) bundles
-          the same thing in one file — and needs the same key.
+          the same thing in one file — and needs the same key. For <b>Traktor</b>,
+          point it at your <b>collection.nml</b> to bring in tracks, playlists, and
+          cues (no key required).
         </div>
       </div>
       <div class="export-row">

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -10746,6 +10746,7 @@ function openImportRekordboxDialog() {
         <label class="export-label">Source</label>
         <div class="export-radios imp-source">
           <label><input type="radio" name="imp_src" value="xml" checked> XML export <span class="export-hint" style="display:inline">— no key required</span></label>
+          <label><input type="radio" name="imp_src" value="nml"> Traktor NML <span class="export-hint" style="display:inline">— collection.nml</span></label>
           <label><input type="radio" name="imp_src" value="db"> master.db <span class="export-hint" style="display:inline">— needs 64-hex SQLCipher key</span></label>
           <label><input type="radio" name="imp_src" value="zip"> Backup .zip <span class="export-hint" style="display:inline">— full: + waveforms, cues, artwork</span></label>
         </div>
@@ -10784,10 +10785,10 @@ function openImportRekordboxDialog() {
       <div class="export-row">
         <label class="export-label">Include</label>
         <div id="imp-include" style="display:flex; flex-wrap:wrap; gap:6px 16px;">
-          <label data-src="xml,db,zip"><input type="checkbox" id="inc-tracks" checked> Tracks <span class="export-hint" style="display:inline">— incl. rating, colour, key</span></label>
-          <label data-src="xml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-playlists" checked> Playlists</label>
+          <label data-src="xml,nml,db,zip"><input type="checkbox" id="inc-tracks" checked> Tracks <span class="export-hint" style="display:inline">— incl. rating, colour, key</span></label>
+          <label data-src="xml,nml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-playlists" checked> Playlists</label>
           <label data-src="xml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-tags" checked> Tags</label>
-          <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-cues" checked> Cues</label>
+          <label data-src="nml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-cues" checked> Cues</label>
           <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-analysis" checked> Waveforms &amp; beat grids</label>
           <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-artwork" checked> Artwork</label>
           <label data-src="db,zip"><input type="checkbox" id="inc-settings" checked> Player/mixer settings</label>
@@ -10838,6 +10839,9 @@ function openImportRekordboxDialog() {
     } else if (src === 'zip') {
       keyRow.style.display = '';
       pathInput.placeholder = '/path/to/rekordbox_bak_YYYYMMDD.zip';
+    } else if (src === 'nml') {
+      keyRow.style.display = 'none';
+      pathInput.placeholder = '/path/to/collection.nml';
     } else {
       keyRow.style.display = 'none';
       pathInput.placeholder = '/path/to/rekordbox.xml';

--- a/library/import_traktor.go
+++ b/library/import_traktor.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package library
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Traktor stores its whole library as a single XML file (collection.nml): a
+// COLLECTION of ENTRY elements plus a nested PLAYLISTS tree. This importer
+// mirrors ImportRekordboxXML — parse entries into library.Track, then walk the
+// playlist node tree — so both importers share the same result shape and the
+// api.go dispatch can treat them uniformly.
+
+type traktorNML struct {
+	XMLName    xml.Name          `xml:"NML"`
+	Version    int               `xml:"VERSION,attr"`
+	Collection traktorCollection `xml:"COLLECTION"`
+	Playlists  traktorPlaylists  `xml:"PLAYLISTS"`
+}
+
+type traktorCollection struct {
+	Entries int            `xml:"ENTRIES,attr"`
+	Tracks  []traktorEntry `xml:"ENTRY"`
+}
+
+type traktorEntry struct {
+	Title      string          `xml:"TITLE,attr"`
+	Artist     string          `xml:"ARTIST,attr"`
+	Location   traktorLocation `xml:"LOCATION"`
+	Album      traktorAlbum    `xml:"ALBUM"`
+	Info       traktorInfo     `xml:"INFO"`
+	Tempo      traktorTempo    `xml:"TEMPO"`
+	MusicalKey *traktorKey     `xml:"MUSICAL_KEY"`
+	Cues       []traktorCue    `xml:"CUE_V2"`
+}
+
+type traktorCue struct {
+	Name   string  `xml:"NAME,attr"`
+	Type   int     `xml:"TYPE,attr"`   // 0=cue 1=fade-in 2=fade-out 3=load 4=grid 5=loop
+	Start  float64 `xml:"START,attr"`  // milliseconds
+	Len    float64 `xml:"LEN,attr"`    // milliseconds (loop length)
+	Hotcue int     `xml:"HOTCUE,attr"` // -1 = memory cue, else 0-7 hot-cue slot
+}
+
+const (
+	traktorCueTypeCue  = 0
+	traktorCueTypeGrid = 4
+	traktorCueTypeLoop = 5
+)
+
+type traktorLocation struct {
+	Dir    string `xml:"DIR,attr"`
+	File   string `xml:"FILE,attr"`
+	Volume string `xml:"VOLUME,attr"`
+}
+
+type traktorAlbum struct {
+	Title string `xml:"TITLE,attr"`
+	Track int    `xml:"TRACK,attr"`
+}
+
+type traktorInfo struct {
+	Bitrate     int    `xml:"BITRATE,attr"` // bits/sec
+	Genre       string `xml:"GENRE,attr"`
+	Comment     string `xml:"COMMENT,attr"`
+	Label       string `xml:"LABEL,attr"`
+	Remixer     string `xml:"REMIXER,attr"`
+	Key         string `xml:"KEY,attr"` // text key, e.g. "Am" (may be empty)
+	Playtime    int    `xml:"PLAYTIME,attr"`
+	ImportDate  string `xml:"IMPORT_DATE,attr"`
+	ReleaseDate string `xml:"RELEASE_DATE,attr"`
+	Filesize    int64  `xml:"FILESIZE,attr"` // kilobytes
+	Ranking     int    `xml:"RANKING,attr"`  // 0-255
+	Playcount   int    `xml:"PLAYCOUNT,attr"`
+}
+
+type traktorTempo struct {
+	BPM float64 `xml:"BPM,attr"`
+}
+
+type traktorKey struct {
+	Value int `xml:"VALUE,attr"` // 0-23
+}
+
+type traktorPlaylists struct {
+	Root traktorNode `xml:"NODE"`
+}
+
+type traktorNode struct {
+	Type     string           `xml:"TYPE,attr"` // "FOLDER" or "PLAYLIST"
+	Name     string           `xml:"NAME,attr"`
+	Subnodes []traktorNode    `xml:"SUBNODES>NODE"`
+	Playlist *traktorPlaylist `xml:"PLAYLIST"`
+}
+
+type traktorPlaylist struct {
+	Entries int                    `xml:"ENTRIES,attr"`
+	Rows    []traktorPlaylistEntry `xml:"ENTRY"`
+}
+
+type traktorPlaylistEntry struct {
+	PrimaryKey traktorPrimaryKey `xml:"PRIMARYKEY"`
+}
+
+type traktorPrimaryKey struct {
+	Type string `xml:"TYPE,attr"` // "TRACK"
+	Key  string `xml:"KEY,attr"`  // VOLUME+DIR+FILE location key
+}
+
+// ImportTraktorNML imports a Traktor collection.nml. It returns cues (hot cues,
+// memory cues, and loops from CUE_V2) in the same MasterDBCue carrier the
+// api.go applier already consumes; Traktor has no MyTags or per-track colours,
+// so those two slices are always nil.
+func ImportTraktorNML(lib *Library, nmlPath string) (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, []MasterDBCue, error) {
+	data, err := os.ReadFile(nmlPath)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("read nml: %w", err)
+	}
+	var doc traktorNML
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("parse nml: %w", err)
+	}
+	log.Printf("import: Traktor NML v%d, %d entries declared",
+		doc.Version, doc.Collection.Entries)
+
+	res := &ImportResult{TracksTotal: len(doc.Collection.Tracks)}
+	// Traktor playlists reference tracks by their location key (VOLUME+DIR+FILE
+	// with Traktor's "/:" separators) rather than a numeric ID, so index by it.
+	idMap := make(map[string]uint32, len(doc.Collection.Tracks))
+	var cues []MasterDBCue
+	for i := range doc.Collection.Tracks {
+		t := &doc.Collection.Tracks[i]
+		path := traktorLocationToPath(t.Location)
+		if path == "" {
+			res.Errors = append(res.Errors, fmt.Sprintf("entry %q: empty LOCATION", t.Title))
+			res.TracksSkipped++
+			continue
+		}
+		track := traktorEntryToLibrary(t, path)
+
+		existing := lib.TrackByPath(path)
+		var id uint32
+		if existing != nil {
+			mergeTrack(existing, track)
+			id = existing.ID
+			res.TracksUpdated++
+		} else {
+			id = lib.AddTrackBulk(track)
+			res.TracksAdded++
+		}
+		idMap[traktorLocationKey(t.Location)] = id
+		cues = append(cues, traktorCues(id, t.Cues)...)
+	}
+
+	// The root node is Traktor's "$ROOT" wrapper; import its children directly.
+	imports := make([]PlaylistImport, 0, len(doc.Playlists.Root.Subnodes))
+	for i := range doc.Playlists.Root.Subnodes {
+		imports = append(imports, traktorNodeToImport(&doc.Playlists.Root.Subnodes[i], idMap))
+	}
+	res.PlaylistsTotal = countTraktorPlaylists(doc.Playlists.Root.Subnodes)
+
+	lib.FinalizeBulk()
+	return res, imports, nil, nil, cues, nil
+}
+
+// traktorCues converts a track's CUE_V2 markers to the neutral MasterDBCue
+// carrier. Grid anchors (TYPE 4, the beat grid) are dropped; hot cues (HOTCUE
+// 0-7) map to slots 1-8 to match the applier's convention, and memory markers
+// are kept only when they are plain cues or loops (fade-in/out/load markers are
+// skipped as clutter). Traktor CUE_V2 carries no per-cue colour.
+func traktorCues(trackID uint32, cs []traktorCue) []MasterDBCue {
+	var out []MasterDBCue
+	for _, c := range cs {
+		if c.Type == traktorCueTypeGrid {
+			continue
+		}
+		isHot := c.Hotcue >= 0 && c.Hotcue <= 7
+		if !isHot && c.Type != traktorCueTypeCue && c.Type != traktorCueTypeLoop {
+			continue
+		}
+		mc := MasterDBCue{
+			TrackID: trackID,
+			HotCue:  -1,
+			TimeMs:  uint32(c.Start + 0.5),
+			LoopMs:  -1,
+			Comment: c.Name,
+		}
+		if isHot {
+			mc.HotCue = c.Hotcue + 1
+		}
+		if c.Type == traktorCueTypeLoop && c.Len > 0 {
+			mc.LoopMs = int32(c.Len + 0.5)
+		}
+		out = append(out, mc)
+	}
+	return out
+}
+
+// traktorLocationKey rebuilds the collection key Traktor uses in playlist
+// PRIMARYKEY entries: VOLUME + DIR + FILE, keeping the raw "/:" separators.
+func traktorLocationKey(loc traktorLocation) string {
+	return loc.Volume + loc.Dir + loc.File
+}
+
+var winDriveRe = regexp.MustCompile(`^[A-Za-z]:$`)
+
+// traktorLocationToPath converts a Traktor LOCATION to a filesystem path.
+// Traktor encodes the directory with "/:" as the separator (e.g.
+// "/:Users/:me/:Music/:"); the real path is that with "/:" → "/" plus FILE. A
+// Windows drive volume ("C:") is prepended; a macOS/Linux boot volume is left
+// off (its paths are already absolute under "/"). Returns "" if there is no
+// file component.
+func traktorLocationToPath(loc traktorLocation) string {
+	if loc.File == "" {
+		return ""
+	}
+	path := strings.ReplaceAll(loc.Dir, "/:", "/") + loc.File
+	if winDriveRe.MatchString(loc.Volume) {
+		path = loc.Volume + path
+	}
+	return path
+}
+
+func traktorEntryToLibrary(t *traktorEntry, path string) *Track {
+	ext := strings.ToLower(filepath.Ext(path))
+	ft := strings.TrimPrefix(ext, ".")
+	if ft == "aif" {
+		ft = "aiff"
+	}
+	dateAdded, _ := time.Parse("2006/1/2", t.Info.ImportDate)
+	if dateAdded.IsZero() {
+		dateAdded = time.Now()
+	}
+	year := 0
+	if rd, err := time.Parse("2006/1/2", t.Info.ReleaseDate); err == nil {
+		year = rd.Year()
+	}
+	key := t.Info.Key
+	if key == "" && t.MusicalKey != nil {
+		key = traktorKeyName(t.MusicalKey.Value)
+	}
+	return &Track{
+		Title:     t.Title,
+		Artist:    t.Artist,
+		Album:     t.Album.Title,
+		Genre:     t.Info.Genre,
+		Duration:  DurationSec(time.Duration(t.Info.Playtime) * time.Second),
+		BPM:       t.Tempo.BPM,
+		Key:       key,
+		Rating:    uint8(t.Info.Ranking / 51), // Traktor 0-255 → 0-5 stars
+		Year:      year,
+		TrackNum:  t.Album.Track,
+		FilePath:  path,
+		FileType:  ft,
+		FileSize:  t.Info.Filesize * 1024, // Traktor stores kilobytes
+		Comment:   t.Info.Comment,
+		Label:     t.Info.Label,
+		Remixer:   t.Info.Remixer,
+		DateAdded: dateAdded,
+		Bitrate:   t.Info.Bitrate / 1000, // Traktor stores bits/sec → kbps
+		PlayCount: t.Info.Playcount,
+	}
+}
+
+// traktorKeyNames maps Traktor's MUSICAL_KEY VALUE (0-23) to standard notation:
+// 0-11 are the chromatic major keys from C, 12-23 the chromatic minor keys.
+var traktorKeyNames = [24]string{
+	"C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B",
+	"Cm", "Dbm", "Dm", "Ebm", "Em", "Fm", "Gbm", "Gm", "Abm", "Am", "Bbm", "Bm",
+}
+
+func traktorKeyName(v int) string {
+	if v < 0 || v >= len(traktorKeyNames) {
+		return ""
+	}
+	return traktorKeyNames[v]
+}
+
+func traktorNodeToImport(n *traktorNode, idMap map[string]uint32) PlaylistImport {
+	if strings.EqualFold(n.Type, "FOLDER") {
+		pi := PlaylistImport{Name: n.Name, IsFolder: true}
+		for i := range n.Subnodes {
+			pi.Children = append(pi.Children, traktorNodeToImport(&n.Subnodes[i], idMap))
+		}
+		return pi
+	}
+	pi := PlaylistImport{Name: n.Name}
+	if n.Playlist != nil {
+		for _, e := range n.Playlist.Rows {
+			if id, ok := idMap[e.PrimaryKey.Key]; ok {
+				pi.TrackIDs = append(pi.TrackIDs, id)
+			}
+		}
+	}
+	return pi
+}
+
+func countTraktorPlaylists(nodes []traktorNode) int {
+	n := 0
+	for i := range nodes {
+		if strings.EqualFold(nodes[i].Type, "FOLDER") {
+			n += countTraktorPlaylists(nodes[i].Subnodes)
+		} else {
+			n++
+		}
+	}
+	return n
+}

--- a/library/import_traktor_test.go
+++ b/library/import_traktor_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package library
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleNML = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<NML VERSION="19">
+  <COLLECTION ENTRIES="2">
+    <ENTRY MODIFIED_DATE="2024/1/2" TITLE="First Track" ARTIST="Alpha">
+      <LOCATION DIR="/:Users/:me/:Music/:" FILE="first.mp3" VOLUME="Macintosh HD"></LOCATION>
+      <ALBUM TITLE="Debut" TRACK="3"></ALBUM>
+      <INFO BITRATE="320000" GENRE="Techno" COMMENT="hello" LABEL="Lbl" RANKING="204"
+            PLAYTIME="360" IMPORT_DATE="2024/1/2" RELEASE_DATE="2020/5/1"
+            FILESIZE="8192" PLAYCOUNT="7" KEY="Am"></INFO>
+      <TEMPO BPM="128.000000" BPM_QUALITY="100.000000"></TEMPO>
+      <MUSICAL_KEY VALUE="21"></MUSICAL_KEY>
+      <CUE_V2 NAME="AutoGrid" TYPE="4" START="0.0" LEN="0.0" HOTCUE="-1"></CUE_V2>
+      <CUE_V2 NAME="Intro" TYPE="0" START="1000.0" LEN="0.0" HOTCUE="0"></CUE_V2>
+      <CUE_V2 NAME="Drop" TYPE="0" START="2000.4" LEN="0.0" HOTCUE="2"></CUE_V2>
+      <CUE_V2 NAME="Mem" TYPE="0" START="5000.0" LEN="0.0" HOTCUE="-1"></CUE_V2>
+      <CUE_V2 NAME="TheLoop" TYPE="5" START="8000.0" LEN="2000.0" HOTCUE="1"></CUE_V2>
+      <CUE_V2 NAME="FadeIn" TYPE="1" START="9000.0" LEN="0.0" HOTCUE="-1"></CUE_V2>
+    </ENTRY>
+    <ENTRY TITLE="Second Track" ARTIST="Beta">
+      <LOCATION DIR="/:Users/:me/:Music/:" FILE="second.flac" VOLUME="Macintosh HD"></LOCATION>
+      <INFO GENRE="House" PLAYTIME="200"></INFO>
+      <TEMPO BPM="124.500000"></TEMPO>
+      <MUSICAL_KEY VALUE="0"></MUSICAL_KEY>
+    </ENTRY>
+  </COLLECTION>
+  <PLAYLISTS>
+    <NODE TYPE="FOLDER" NAME="$ROOT">
+      <SUBNODES COUNT="2">
+        <NODE TYPE="PLAYLIST" NAME="Warmup">
+          <PLAYLIST ENTRIES="2" TYPE="LIST">
+            <ENTRY><PRIMARYKEY TYPE="TRACK" KEY="Macintosh HD/:Users/:me/:Music/:first.mp3"></PRIMARYKEY></ENTRY>
+            <ENTRY><PRIMARYKEY TYPE="TRACK" KEY="Macintosh HD/:Users/:me/:Music/:second.flac"></PRIMARYKEY></ENTRY>
+          </PLAYLIST>
+        </NODE>
+        <NODE TYPE="FOLDER" NAME="Gigs">
+          <SUBNODES COUNT="1">
+            <NODE TYPE="PLAYLIST" NAME="Peak">
+              <PLAYLIST ENTRIES="1" TYPE="LIST">
+                <ENTRY><PRIMARYKEY TYPE="TRACK" KEY="Macintosh HD/:Users/:me/:Music/:first.mp3"></PRIMARYKEY></ENTRY>
+              </PLAYLIST>
+            </NODE>
+          </SUBNODES>
+        </NODE>
+      </SUBNODES>
+    </NODE>
+  </PLAYLISTS>
+</NML>`
+
+func TestImportTraktorNML(t *testing.T) {
+	dir := t.TempDir()
+	nml := filepath.Join(dir, "collection.nml")
+	if err := os.WriteFile(nml, []byte(sampleNML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lib := NewLibrary(nil, nil)
+	res, playlists, tags, colors, cues, err := ImportTraktorNML(lib, nml)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if tags != nil || colors != nil {
+		t.Errorf("expected nil tags/colors, got %v / %v", tags, colors)
+	}
+	if res.TracksTotal != 2 || res.TracksAdded != 2 {
+		t.Errorf("counts: total=%d added=%d, want 2/2", res.TracksTotal, res.TracksAdded)
+	}
+
+	tr := lib.TrackByPath("/Users/me/Music/first.mp3")
+	if tr == nil {
+		t.Fatal("first.mp3 not imported at reconstructed path")
+	}
+	if tr.Title != "First Track" || tr.Artist != "Alpha" || tr.Album != "Debut" {
+		t.Errorf("metadata: %q / %q / %q", tr.Title, tr.Artist, tr.Album)
+	}
+	if tr.BPM != 128.0 {
+		t.Errorf("bpm=%v want 128", tr.BPM)
+	}
+	if tr.Key != "Am" { // INFO KEY wins over MUSICAL_KEY
+		t.Errorf("key=%q want Am", tr.Key)
+	}
+	if tr.Rating != 4 { // 204/51
+		t.Errorf("rating=%d want 4", tr.Rating)
+	}
+	if tr.Genre != "Techno" || tr.Label != "Lbl" || tr.PlayCount != 7 {
+		t.Errorf("genre/label/playcount: %q/%q/%d", tr.Genre, tr.Label, tr.PlayCount)
+	}
+	if tr.Bitrate != 320 {
+		t.Errorf("bitrate=%d want 320 kbps", tr.Bitrate)
+	}
+	if tr.Year != 2020 {
+		t.Errorf("year=%d want 2020", tr.Year)
+	}
+	if tr.TrackNum != 3 {
+		t.Errorf("tracknum=%d want 3", tr.TrackNum)
+	}
+
+	// Cues: the grid anchor (TYPE 4) and fade-in (TYPE 1 memory) are dropped;
+	// the two hot cues, one memory cue, and one hot loop remain, in order.
+	if len(cues) != 4 {
+		t.Fatalf("cues=%d want 4: %+v", len(cues), cues)
+	}
+	want := []MasterDBCue{
+		{TrackID: tr.ID, HotCue: 1, TimeMs: 1000, LoopMs: -1, Comment: "Intro"},     // HOTCUE 0 → slot 1
+		{TrackID: tr.ID, HotCue: 3, TimeMs: 2000, LoopMs: -1, Comment: "Drop"},      // 2000.4 rounds down
+		{TrackID: tr.ID, HotCue: -1, TimeMs: 5000, LoopMs: -1, Comment: "Mem"},      // memory cue
+		{TrackID: tr.ID, HotCue: 2, TimeMs: 8000, LoopMs: 2000, Comment: "TheLoop"}, // hot loop
+	}
+	for i, w := range want {
+		if cues[i] != w {
+			t.Errorf("cue[%d] = %+v, want %+v", i, cues[i], w)
+		}
+	}
+
+	// Second track: no INFO KEY, so MUSICAL_KEY VALUE=0 → "C".
+	tr2 := lib.TrackByPath("/Users/me/Music/second.flac")
+	if tr2 == nil || tr2.Key != "C" || tr2.FileType != "flac" {
+		t.Errorf("second track: %+v", tr2)
+	}
+
+	// Playlist tree: root has [Warmup(2 tracks), Gigs(folder → Peak(1 track))].
+	if res.PlaylistsTotal != 2 {
+		t.Errorf("playlists total=%d want 2", res.PlaylistsTotal)
+	}
+	if len(playlists) != 2 {
+		t.Fatalf("top-level nodes=%d want 2", len(playlists))
+	}
+	warmup := playlists[0]
+	if warmup.Name != "Warmup" || warmup.IsFolder || len(warmup.TrackIDs) != 2 {
+		t.Errorf("warmup: %+v", warmup)
+	}
+	gigs := playlists[1]
+	if gigs.Name != "Gigs" || !gigs.IsFolder || len(gigs.Children) != 1 {
+		t.Fatalf("gigs: %+v", gigs)
+	}
+	peak := gigs.Children[0]
+	if peak.Name != "Peak" || len(peak.TrackIDs) != 1 || peak.TrackIDs[0] != tr.ID {
+		t.Errorf("peak: %+v (want 1 track = %d)", peak, tr.ID)
+	}
+}


### PR DESCRIPTION
## What & why

Adds a Traktor NML importer alongside the existing rekordbox XML / master.db / backup importers, so a Traktor user can bring their whole library into Vynull. First non-rekordbox library format. Traktor stores everything in one XML file (collection.nml), so this mirrors the rekordbox-XML importer and plugs into the same import pipeline.

Imports:

- Tracks: title, artist, album, genre, BPM, key, rating, year, track number, label, comment, play count, bitrate, file size. Key prefers the text INFO KEY (e.g. "Am") and falls back to mapping Traktor's MUSICAL_KEY VALUE (0 to 23) to standard notation; rating maps Traktor's 0 to 255 scale to 0 to 5 stars; bitrate converts bits/s to kbps.
- Playlists: the full nested folder + playlist tree, resolving each PRIMARYKEY back to a track via its VOLUME+DIR+FILE location key.
- Cues: hot cues (Traktor's 0 to 7 mapped to the 1 to 8 slot convention), memory cues, and loops from CUE_V2, reusing the existing import cue carrier so they land in the cue store with no new plumbing. The grid anchor (TYPE 4) and stray fade markers are dropped.

Paths: Traktor encodes the directory with "/:" separators, so the importer rebuilds the real path, prepends a Windows drive volume, and leaves the mac/Linux boot volume off. Files that do not resolve locally fall through to the existing missing-file flagging and the import dialog's path-remap field, exactly like a rekordbox import from another machine.

UI: the import dialog gets a Traktor source radio, the tracks/playlists/cues include options, and a collection.nml placeholder. Because the form now handles more than rekordbox, the source-specific copy is generalized ("Import your library" / "Import a library", "IMPORT LIBRARY").

Caveats: best-effort path reconstruction across platforms, and worth validating against a real collection.nml since the NML format drifts between Traktor versions. Traktor CUE_V2 carries no per-cue colour, so imported cues take the default.

## Hardware testing

- **Tested on:** N/A for code paths: no change to the load, serve, or analysis code; imported tracks and cues flow to decks through the existing rekordbox serving path. That said, this feeds new data (Traktor-authored cues, BPM, paths) to a deck for the first time, so a sanity check on hardware (load a Traktor-imported track, confirm it plays and its hot cues render) is recommended before relying on it. <!-- update if you run it -->

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [ ] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
