### PR TITLE
library: generalize the import layer behind an Importer registry

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -16,7 +15,6 @@ import (
 	"image"
 	"image/color"
 	"image/png"
-	"io"
 	"log"
 	"math"
 	"net"
@@ -883,116 +881,44 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 	s.importBegin("Reading rekordbox database…")
 	defer s.importEnd()
 
-	ext := strings.ToLower(filepath.Ext(req.Path))
-	var result *library.ImportResult
-	var playlists []library.PlaylistImport
-	var tags []library.TagImport
-	var colors []library.ColorImport
-	var assets []library.ImportedAsset   // ANLZ + artwork paths (.zip, or .db in its lib folder)
-	var masterCues []library.ImportedCue // cue points from djmdCue (.db/.zip)
-	var shareRoot string                 // share/ root (.zip extract, or a .db's own folder)
-	var settingsDir string               // *SETTING.DAT dir (.zip extract, or a .db's own folder)
-	var bundle *library.ImportBundle     // importer side-data; destructured into the locals below
-	var err error
-
-	switch ext {
-	case ".xml":
-		if incTracks {
-			bundle, err = library.ImportRekordboxXML(s.Library, req.Path)
-		}
-	case ".nml":
-		if incTracks {
-			bundle, err = library.ImportTraktorNML(s.Library, req.Path)
-		}
-	case ".db":
-		// The master.db is SQLCipher-encrypted; the user supplies the 64-hex
-		// key (the import dialog collects it). We ship no key and don't extract
-		// one, so it is required here.
-		key := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(req.Key), "0x"))
-		if !isHex64(key) {
-			http.Error(w, "a 64-hex SQLCipher key is required", http.StatusBadRequest)
-			return
-		}
-		if incTracks {
-			bundle, err = library.ImportRekordboxMasterDB(s.Library, req.Path, key)
-		}
-		// A master.db that still lives in its rekordbox library folder has its
-		// analysis (share/PIONEER/USBANLZ), artwork (share/PIONEER/Artwork), and
-		// *SETTING.DAT blobs right beside it — the same layout a backup zip
-		// mirrors. Point shareRoot/settingsDir at the DB's own directory so the
-		// asset + settings import below picks them up, making a bare-.db import
-		// nearly as complete as a .zip. (A DB copied out on its own has no
-		// neighbours, so these stay empty and nothing extra is imported.)
-		dbDir := filepath.Dir(req.Path)
-		if fi, e := os.Stat(filepath.Join(dbDir, "share")); e == nil && fi.IsDir() {
-			shareRoot = filepath.Join(dbDir, "share")
-		}
-		if incSettings && s.Settings != nil {
-			hasSettings := func(dir string) bool {
-				for _, sf := range rekordboxSettingsFiles {
-					if _, e := os.Stat(filepath.Join(dir, sf)); e == nil {
-						return true
-					}
-				}
-				return false
-			}
-			// rekordbox 6 keeps the *SETTING.DAT blobs in a sibling "rekordbox6"
-			// folder (master.db lives in "rekordbox"); a backup zip instead puts
-			// them beside the db. Check the sibling first, then the db's dir.
-			for _, cand := range []string{filepath.Join(filepath.Dir(dbDir), "rekordbox6"), dbDir} {
-				if hasSettings(cand) {
-					settingsDir = cand
-					break
-				}
-			}
-		}
-	case ".zip":
-		// rekordbox library backup: master.db (+ share/PIONEER analysis &
-		// artwork, + *SETTING.DAT blobs) inside a zip. Extract to a temp dir,
-		// import the DB, then pull in the ANLZ waveforms/beat grids, cover art,
-		// and settings below. The master.db is SQLCipher-encrypted; the user
-		// supplies the 64-hex key (we ship none and don't extract one).
-		key := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(req.Key), "0x"))
-		if !isHex64(key) {
-			http.Error(w, "a 64-hex SQLCipher key is required", http.StatusBadRequest)
-			return
-		}
-		tmp, terr := os.MkdirTemp("", "rb-backup-*")
-		if terr != nil {
-			http.Error(w, "could not create temp dir: "+terr.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer os.RemoveAll(tmp)
-		var dbPath string
-		s.importPhase("Extracting backup…")
-		dbPath, shareRoot, settingsDir, err = extractRekordboxBackup(req.Path, tmp, incSettings && s.Settings != nil)
-		if err != nil {
-			http.Error(w, "extract backup: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		if incTracks {
-			s.importPhase("Reading rekordbox database…")
-			bundle, err = library.ImportRekordboxMasterDB(s.Library, dbPath, key)
-		}
-	default:
+	imp := library.ImporterFor(req.Path)
+	if imp == nil {
 		http.Error(w, "path must be a .xml, .nml (Traktor), .db, or .zip (rekordbox backup) file", http.StatusBadRequest)
 		return
 	}
+	// Encrypted rekordbox formats (master.db / backup zip) need the user's 64-hex
+	// SQLCipher key — we ship none and don't extract one.
+	key := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(req.Key), "0x"))
+	if imp.RequiresKey(req.Path) && !isHex64(key) {
+		http.Error(w, "a 64-hex SQLCipher key is required", http.StatusBadRequest)
+		return
+	}
 
+	bundle, err := imp.Import(s.Library, library.ImportOptions{
+		Path:         req.Path,
+		Key:          key,
+		WantTracks:   incTracks,
+		WantSettings: incSettings && s.Settings != nil,
+		Progress:     s.importPhase,
+	})
 	if err != nil {
 		http.Error(w, "import failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// Spread the importer's side-data into the locals the apply pipeline below
-	// reads. shareRoot/settingsDir stay handler-managed (set per case above).
-	if bundle != nil {
-		result = bundle.Result
-		playlists = bundle.Playlists
-		tags = bundle.Tags
-		colors = bundle.Colors
-		assets = bundle.Assets
-		masterCues = bundle.Cues
+	if bundle == nil {
+		bundle = &library.ImportBundle{}
 	}
+	if bundle.Cleanup != nil {
+		defer bundle.Cleanup() // release the backup-zip temp dir after apply reads it
+	}
+	result := bundle.Result
+	playlists := bundle.Playlists
+	tags := bundle.Tags
+	colors := bundle.Colors
+	assets := bundle.Assets   // ANLZ + artwork paths (.zip, or .db in its lib folder)
+	masterCues := bundle.Cues // cue points from djmdCue (.db/.zip)
+	shareRoot := bundle.ShareRoot
+	settingsDir := bundle.SettingsDir
 	// !incTracks paths skip the importer entirely (e.g. a settings-only zip
 	// import), so synthesize an empty result for the materialization + summary.
 	if result == nil {
@@ -1348,87 +1274,6 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, result)
-}
-
-// rekordboxSettingsFiles are the player/mixer setting blobs rekordbox writes
-// to the root of a library-backup zip (and to /PIONEER on a USB export).
-var rekordboxSettingsFiles = []string{
-	"MYSETTING.DAT", "MYSETTING2.DAT", "DJMMYSETTING.DAT", "DEVSETTING.DAT",
-}
-
-// extractRekordboxBackup unpacks the parts of a rekordbox library-backup zip
-// we care about — master.db, the share/PIONEER/{USBANLZ,Artwork} trees, and
-// (when wantSettings) the *SETTING.DAT blobs at the zip root — into dest. It
-// returns the extracted master.db path, the share/ root, and the directory
-// holding the settings files (empty if none were extracted). Other entries
-// (lighting DBs, XML prefs, etc.) are skipped. Guards against zip-slip.
-func extractRekordboxBackup(zipPath, dest string, wantSettings bool) (dbPath, shareRoot, settingsDir string, err error) {
-	zr, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return "", "", "", err
-	}
-	defer zr.Close()
-
-	isSettingsFile := func(name string) bool {
-		for _, s := range rekordboxSettingsFiles {
-			if name == s {
-				return true
-			}
-		}
-		return false
-	}
-
-	cleanDest := filepath.Clean(dest)
-	gotSettings := false
-	for _, f := range zr.File {
-		name := f.Name // zip paths use forward slashes
-		settings := wantSettings && isSettingsFile(name)
-		keep := name == "master.db" ||
-			strings.HasPrefix(name, "share/PIONEER/USBANLZ/") ||
-			strings.HasPrefix(name, "share/PIONEER/Artwork/") ||
-			settings
-		if !keep || f.FileInfo().IsDir() {
-			continue
-		}
-		target := filepath.Join(cleanDest, filepath.FromSlash(name))
-		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
-			continue // zip-slip: entry escapes dest
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return "", "", "", err
-		}
-		if err := extractZipEntry(f, target); err != nil {
-			return "", "", "", err
-		}
-		if settings {
-			gotSettings = true
-		}
-	}
-
-	dbPath = filepath.Join(cleanDest, "master.db")
-	if _, err := os.Stat(dbPath); err != nil {
-		return "", "", "", fmt.Errorf("master.db not found in backup zip")
-	}
-	if gotSettings {
-		settingsDir = cleanDest
-	}
-	return dbPath, filepath.Join(cleanDest, "share"), settingsDir, nil
-}
-
-// extractZipEntry copies one zip file entry to target on disk.
-func extractZipEntry(f *zip.File, target string) error {
-	rc, err := f.Open()
-	if err != nil {
-		return err
-	}
-	defer rc.Close()
-	out, err := os.Create(target)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-	_, err = io.Copy(out, rc)
-	return err
 }
 
 // handleRemapPaths rewrites every track whose FilePath starts with

--- a/api/api.go
+++ b/api/api.go
@@ -888,20 +888,21 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 	var playlists []library.PlaylistImport
 	var tags []library.TagImport
 	var colors []library.ColorImport
-	var assets []library.MasterDBAsset   // ANLZ + artwork paths (.zip, or .db in its lib folder)
-	var masterCues []library.MasterDBCue // cue points from djmdCue (.db/.zip)
+	var assets []library.ImportedAsset   // ANLZ + artwork paths (.zip, or .db in its lib folder)
+	var masterCues []library.ImportedCue // cue points from djmdCue (.db/.zip)
 	var shareRoot string                 // share/ root (.zip extract, or a .db's own folder)
 	var settingsDir string               // *SETTING.DAT dir (.zip extract, or a .db's own folder)
+	var bundle *library.ImportBundle     // importer side-data; destructured into the locals below
 	var err error
 
 	switch ext {
 	case ".xml":
 		if incTracks {
-			result, playlists, tags, colors, err = library.ImportRekordboxXML(s.Library, req.Path)
+			bundle, err = library.ImportRekordboxXML(s.Library, req.Path)
 		}
 	case ".nml":
 		if incTracks {
-			result, playlists, tags, colors, masterCues, err = library.ImportTraktorNML(s.Library, req.Path)
+			bundle, err = library.ImportTraktorNML(s.Library, req.Path)
 		}
 	case ".db":
 		// The master.db is SQLCipher-encrypted; the user supplies the 64-hex
@@ -913,7 +914,7 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if incTracks {
-			result, playlists, tags, colors, assets, masterCues, err = library.ImportRekordboxMasterDB(s.Library, req.Path, key)
+			bundle, err = library.ImportRekordboxMasterDB(s.Library, req.Path, key)
 		}
 		// A master.db that still lives in its rekordbox library folder has its
 		// analysis (share/PIONEER/USBANLZ), artwork (share/PIONEER/Artwork), and
@@ -971,7 +972,7 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 		}
 		if incTracks {
 			s.importPhase("Reading rekordbox database…")
-			result, playlists, tags, colors, assets, masterCues, err = library.ImportRekordboxMasterDB(s.Library, dbPath, key)
+			bundle, err = library.ImportRekordboxMasterDB(s.Library, dbPath, key)
 		}
 	default:
 		http.Error(w, "path must be a .xml, .nml (Traktor), .db, or .zip (rekordbox backup) file", http.StatusBadRequest)
@@ -981,6 +982,16 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "import failed: "+err.Error(), http.StatusInternalServerError)
 		return
+	}
+	// Spread the importer's side-data into the locals the apply pipeline below
+	// reads. shareRoot/settingsDir stay handler-managed (set per case above).
+	if bundle != nil {
+		result = bundle.Result
+		playlists = bundle.Playlists
+		tags = bundle.Tags
+		colors = bundle.Colors
+		assets = bundle.Assets
+		masterCues = bundle.Cues
 	}
 	// !incTracks paths skip the importer entirely (e.g. a settings-only zip
 	// import), so synthesize an empty result for the materialization + summary.

--- a/api/api.go
+++ b/api/api.go
@@ -911,6 +911,25 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 	if bundle.Cleanup != nil {
 		defer bundle.Cleanup() // release the backup-zip temp dir after apply reads it
 	}
+	s.applyImportBundle(w, bundle, importInclude{
+		Tracks: incTracks, Playlists: incPlaylists, Tags: incTags, Analysis: incAnalysis,
+		Artwork: incArtwork, Cues: incCues, Settings: incSettings,
+	}, req.RemapFrom, req.RemapTo)
+}
+
+// importInclude selects which categories of an import to materialize.
+type importInclude struct {
+	Tracks, Playlists, Tags, Analysis, Artwork, Cues, Settings bool
+}
+
+// applyImportBundle materializes an importer's ImportBundle into the stores
+// (playlists, tags, colours, cues, analysis, artwork, settings), flags missing
+// audio files, and writes the JSON summary. Split out of handleImportRekordbox
+// so the dispatch stays small; the body is otherwise unchanged from when it ran
+// inline.
+func (s *Server) applyImportBundle(w http.ResponseWriter, bundle *library.ImportBundle, inc importInclude, remapFrom, remapTo string) {
+	incTracks, incPlaylists, incTags := inc.Tracks, inc.Playlists, inc.Tags
+	incAnalysis, incArtwork, incCues, incSettings := inc.Analysis, inc.Artwork, inc.Cues, inc.Settings
 	result := bundle.Result
 	playlists := bundle.Playlists
 	tags := bundle.Tags
@@ -928,9 +947,9 @@ func (s *Server) handleImportRekordbox(w http.ResponseWriter, r *http.Request) {
 	// Optional path-prefix remap (e.g. "Z:/Music/" → "/media/usb/Music/").
 	// Applied after import so it covers tracks added in *this* import as
 	// well as any already present with the matching prefix.
-	if req.RemapFrom != "" && req.RemapTo != "" {
-		n, _ := s.Library.RemapPaths(req.RemapFrom, req.RemapTo)
-		log.Printf("import: remapped %d track paths %q -> %q", n, req.RemapFrom, req.RemapTo)
+	if remapFrom != "" && remapTo != "" {
+		n, _ := s.Library.RemapPaths(remapFrom, remapTo)
+		log.Printf("import: remapped %d track paths %q -> %q", n, remapFrom, remapTo)
 	}
 
 	s.Library.Save()

--- a/core/doc.go
+++ b/core/doc.go
@@ -2,8 +2,9 @@
 
 // Package core is the brand-neutral heart of vynull: the domain model (tracks,
 // cues, playlists, analysis, player state) and the interfaces that pluggable
-// adapters implement — live link protocols (Backend/Source) and library file
-// formats (Importer/Exporter).
+// adapters implement — live link protocols (Backend/Source) and library export
+// formats (Exporter). Import adapters live in package library (see
+// docs/design/import-layer.md).
 //
 // Dependency rule: core imports nothing from analysis, link/*, format/*, or api;
 // everything else imports core. Keeping the model and contracts free of any one

--- a/core/format.go
+++ b/core/format.go
@@ -2,33 +2,18 @@
 
 package core
 
-// Library is a neutral snapshot of tracks and playlists — the currency of the
-// import/export adapters.
+// Library is a neutral snapshot of tracks and playlists — what the export
+// adapters consume. (Import adapters live in package library, working against
+// the concrete library.Library; see docs/design/import-layer.md.)
 type Library struct {
 	Tracks    []*Track
 	Playlists []*Playlist
-}
-
-// ImportOptions carries adapter-agnostic import knobs; a specific importer may
-// define its own richer options.
-type ImportOptions struct {
-	// RemapPath, when set, rewrites an imported absolute path onto a local file.
-	RemapPath func(string) string
 }
 
 // ExportOptions carries adapter-agnostic export knobs.
 type ExportOptions struct {
 	// CopyFiles copies audio into the destination instead of referencing it.
 	CopyFiles bool
-}
-
-// Importer reads a foreign library (rekordbox XML/master.db, Engine, Serato, …)
-// into the neutral model.
-type Importer interface {
-	Name() string
-	// Detect reports whether path looks like this format (a directory or file).
-	Detect(path string) bool
-	Import(path string, opts ImportOptions) (*Library, error)
 }
 
 // Exporter writes the neutral model out in a foreign format (rekordbox USB/PDB,

--- a/library/import.go
+++ b/library/import.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package library
+
+// ImportBundle is the neutral result every library importer returns. The tracks
+// themselves are added straight into the Library during the import; this carries
+// the side-data the api-side applier materializes afterwards: the playlist tree,
+// MyTags, track colours, cues, and — for rekordbox master.db / backup imports —
+// the ANLZ + artwork asset paths.
+//
+// (import-layer phase 1: unifies the previously divergent importer return
+// signatures. ShareRoot / SettingsDir join here in phase 2, once the backup-zip
+// container becomes an Importer; today the api handler still manages those.)
+type ImportBundle struct {
+	Result    *ImportResult
+	Playlists []PlaylistImport
+	Tags      []TagImport
+	Colors    []ColorImport
+	Cues      []ImportedCue
+	Assets    []ImportedAsset
+}

--- a/library/import.go
+++ b/library/import.go
@@ -2,15 +2,16 @@
 
 package library
 
+import (
+	"path/filepath"
+	"strings"
+)
+
 // ImportBundle is the neutral result every library importer returns. The tracks
 // themselves are added straight into the Library during the import; this carries
 // the side-data the api-side applier materializes afterwards: the playlist tree,
 // MyTags, track colours, cues, and — for rekordbox master.db / backup imports —
-// the ANLZ + artwork asset paths.
-//
-// (import-layer phase 1: unifies the previously divergent importer return
-// signatures. ShareRoot / SettingsDir join here in phase 2, once the backup-zip
-// container becomes an Importer; today the api handler still manages those.)
+// the ANLZ + artwork asset paths plus the roots they live under.
 type ImportBundle struct {
 	Result    *ImportResult
 	Playlists []PlaylistImport
@@ -18,4 +19,68 @@ type ImportBundle struct {
 	Colors    []ColorImport
 	Cues      []ImportedCue
 	Assets    []ImportedAsset
+	// ShareRoot is the share/ root for ANLZ + artwork (a backup-zip extract, or
+	// a master.db's own library folder). SettingsDir holds the *SETTING.DAT
+	// blobs. Both are empty when the format carries no such assets.
+	ShareRoot   string
+	SettingsDir string
+	// Cleanup releases any transient resources the import created (the backup-zip
+	// temp dir). The caller MUST defer it, after the apply pipeline has read
+	// ShareRoot/SettingsDir. Nil when there is nothing to release.
+	Cleanup func()
+}
+
+// ImportOptions parameterizes an import. WantTracks gates the track import; a
+// false value still lets an importer surface ShareRoot/SettingsDir for a
+// settings/analysis-only import. WantSettings gates locating *SETTING.DAT (the
+// caller ANDs the user's include flag with its own settings-store capability).
+// Progress, if set, receives human-readable phase updates.
+type ImportOptions struct {
+	Path         string
+	Key          string
+	WantTracks   bool
+	WantSettings bool
+	Progress     func(msg string)
+}
+
+func (o ImportOptions) note(msg string) {
+	if o.Progress != nil {
+		o.Progress(msg)
+	}
+}
+
+// Importer reads one source library format into the Library.
+type Importer interface {
+	// Label is a short human name, e.g. "rekordbox XML", "Traktor NML".
+	Label() string
+	// Handles reports whether this importer claims path (by extension).
+	Handles(path string) bool
+	// RequiresKey reports whether path needs a decryption key.
+	RequiresKey(path string) bool
+	// Import reads path and populates lib, returning the side-data bundle.
+	Import(lib *Library, opt ImportOptions) (*ImportBundle, error)
+}
+
+// Importers is the importer registry, in resolution order.
+func Importers() []Importer {
+	return []Importer{
+		rekordboxXMLImporter{},
+		rekordboxBackupImporter{},
+		rekordboxDBImporter{},
+		traktorImporter{},
+	}
+}
+
+// ImporterFor returns the importer that handles path, or nil if none does.
+func ImporterFor(path string) Importer {
+	for _, imp := range Importers() {
+		if imp.Handles(path) {
+			return imp
+		}
+	}
+	return nil
+}
+
+func hasExt(path, ext string) bool {
+	return strings.EqualFold(filepath.Ext(path), ext)
 }

--- a/library/import_masterdb.go
+++ b/library/import_masterdb.go
@@ -30,9 +30,9 @@ type masterDBCue struct {
 	Comment   string `json:"comment"`
 }
 
-// MasterDBCue is a djmdCue row with its rekordbox ContentID resolved to a
+// ImportedCue is a djmdCue row with its rekordbox ContentID resolved to a
 // library Track.ID. HotCue 0 = memory cue, 1..8 = hot cue A..H.
-type MasterDBCue struct {
+type ImportedCue struct {
 	TrackID uint32
 	HotCue  int
 	TimeMs  uint32
@@ -86,11 +86,11 @@ type masterDBTrack struct {
 	ImagePath   string  `json:"image_path"`   // /PIONEER/Artwork/.../artwork.jpg, relative to share/
 }
 
-// MasterDBAsset pairs a library Track.ID with the rekordbox-relative paths
+// ImportedAsset pairs a library Track.ID with the rekordbox-relative paths
 // to its analysis (ANLZ) and artwork files inside a backup's share/ tree.
 // The caller resolves these against the extracted backup directory to import
 // the existing waveforms/beat grids and cover art.
-type MasterDBAsset struct {
+type ImportedAsset struct {
 	TrackID     uint32
 	AnalyzePath string // e.g. /PIONEER/USBANLZ/<bucket>/<uuid>/ANLZ0000.DAT
 	ImagePath   string // e.g. /PIONEER/Artwork/<bucket>/<uuid>/artwork.jpg
@@ -141,20 +141,19 @@ type MasterDBTag struct {
 // decryption key for the user's own database, supplied by the caller — this
 // project ships no key and does not extract one.
 //
-// Returns the same shape as ImportRekordboxXML: the resolved playlist tree
-// ([]PlaylistImport, track IDs already mapped to library Track.IDs), the
-// MyTags and track colours (also resolved, matching []TagImport/[]ColorImport),
-// and []MasterDBAsset carrying each track's ANLZ + artwork paths (relative to
+// Returns an ImportBundle like the other importers: the resolved playlist tree
+// (track IDs already mapped to library Track.IDs), the MyTags, track colours,
+// and cues, plus Assets carrying each track's ANLZ + artwork paths (relative to
 // the backup's share/ root) for the caller to import.
-func ImportRekordboxMasterDB(lib *Library, dbPath, key string) (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, []MasterDBAsset, []MasterDBCue, error) {
+func ImportRekordboxMasterDB(lib *Library, dbPath, key string) (*ImportBundle, error) {
 	dump, err := runMasterDBDump(dbPath, key)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, err
 	}
 	res := &ImportResult{TracksTotal: len(dump.Tracks)}
 	idMap := make(map[string]uint32, len(dump.Tracks)) // rekordbox ContentID → library Track.ID
 	var colors []ColorImport
-	var assets []MasterDBAsset
+	var assets []ImportedAsset
 	for _, t := range dump.Tracks {
 		path := t.FilePath
 		if path != "" && t.FileName != "" && !strings.HasSuffix(path, t.FileName) {
@@ -183,7 +182,7 @@ func ImportRekordboxMasterDB(lib *Library, dbPath, key string) (*ImportResult, [
 			colors = append(colors, ColorImport{TrackID: id, ColorID: track.ColorID})
 		}
 		if t.AnalyzePath != "" || t.ImagePath != "" {
-			assets = append(assets, MasterDBAsset{TrackID: id, AnalyzePath: t.AnalyzePath, ImagePath: t.ImagePath})
+			assets = append(assets, ImportedAsset{TrackID: id, AnalyzePath: t.AnalyzePath, ImagePath: t.ImagePath})
 		}
 	}
 
@@ -220,13 +219,13 @@ func ImportRekordboxMasterDB(lib *Library, dbPath, key string) (*ImportResult, [
 	res.PlaylistsTotal = countPlaylists2(playlists)
 
 	// Resolve cue points to library track IDs. OutMsec -1 means "not a loop".
-	cues := make([]MasterDBCue, 0, len(dump.Cues))
+	cues := make([]ImportedCue, 0, len(dump.Cues))
 	for _, c := range dump.Cues {
 		id, ok := idMap[c.ContentID]
 		if !ok {
 			continue
 		}
-		mc := MasterDBCue{TrackID: id, HotCue: hotCueSlot(c.Kind), TimeMs: uint32(c.InMsec), LoopMs: -1, Comment: c.Comment}
+		mc := ImportedCue{TrackID: id, HotCue: hotCueSlot(c.Kind), TimeMs: uint32(c.InMsec), LoopMs: -1, Comment: c.Comment}
 		if c.OutMsec > 0 {
 			mc.LoopMs = int32(c.OutMsec)
 		}
@@ -243,7 +242,7 @@ func ImportRekordboxMasterDB(lib *Library, dbPath, key string) (*ImportResult, [
 	}
 
 	lib.FinalizeBulk()
-	return res, playlists, tags, colors, assets, cues, nil
+	return &ImportBundle{Result: res, Playlists: playlists, Tags: tags, Colors: colors, Assets: assets, Cues: cues}, nil
 }
 
 // masterDBPlaylistTree turns the flat djmdPlaylist rows into a nested

--- a/library/import_traktor.go
+++ b/library/import_traktor.go
@@ -115,18 +115,18 @@ type traktorPrimaryKey struct {
 	Key  string `xml:"KEY,attr"`  // VOLUME+DIR+FILE location key
 }
 
-// ImportTraktorNML imports a Traktor collection.nml. It returns cues (hot cues,
-// memory cues, and loops from CUE_V2) in the same MasterDBCue carrier the
+// ImportTraktorNML imports a Traktor collection.nml. Cues (hot cues, memory
+// cues, and loops from CUE_V2) come back in the bundle's ImportedCue carrier the
 // api.go applier already consumes; Traktor has no MyTags or per-track colours,
-// so those two slices are always nil.
-func ImportTraktorNML(lib *Library, nmlPath string) (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, []MasterDBCue, error) {
+// so the bundle's Tags/Colors are always nil.
+func ImportTraktorNML(lib *Library, nmlPath string) (*ImportBundle, error) {
 	data, err := os.ReadFile(nmlPath)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("read nml: %w", err)
+		return nil, fmt.Errorf("read nml: %w", err)
 	}
 	var doc traktorNML
 	if err := xml.Unmarshal(data, &doc); err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("parse nml: %w", err)
+		return nil, fmt.Errorf("parse nml: %w", err)
 	}
 	log.Printf("import: Traktor NML v%d, %d entries declared",
 		doc.Version, doc.Collection.Entries)
@@ -135,7 +135,7 @@ func ImportTraktorNML(lib *Library, nmlPath string) (*ImportResult, []PlaylistIm
 	// Traktor playlists reference tracks by their location key (VOLUME+DIR+FILE
 	// with Traktor's "/:" separators) rather than a numeric ID, so index by it.
 	idMap := make(map[string]uint32, len(doc.Collection.Tracks))
-	var cues []MasterDBCue
+	var cues []ImportedCue
 	for i := range doc.Collection.Tracks {
 		t := &doc.Collection.Tracks[i]
 		path := traktorLocationToPath(t.Location)
@@ -168,16 +168,16 @@ func ImportTraktorNML(lib *Library, nmlPath string) (*ImportResult, []PlaylistIm
 	res.PlaylistsTotal = countTraktorPlaylists(doc.Playlists.Root.Subnodes)
 
 	lib.FinalizeBulk()
-	return res, imports, nil, nil, cues, nil
+	return &ImportBundle{Result: res, Playlists: imports, Cues: cues}, nil
 }
 
-// traktorCues converts a track's CUE_V2 markers to the neutral MasterDBCue
+// traktorCues converts a track's CUE_V2 markers to the neutral ImportedCue
 // carrier. Grid anchors (TYPE 4, the beat grid) are dropped; hot cues (HOTCUE
 // 0-7) map to slots 1-8 to match the applier's convention, and memory markers
 // are kept only when they are plain cues or loops (fade-in/out/load markers are
 // skipped as clutter). Traktor CUE_V2 carries no per-cue colour.
-func traktorCues(trackID uint32, cs []traktorCue) []MasterDBCue {
-	var out []MasterDBCue
+func traktorCues(trackID uint32, cs []traktorCue) []ImportedCue {
+	var out []ImportedCue
 	for _, c := range cs {
 		if c.Type == traktorCueTypeGrid {
 			continue
@@ -186,7 +186,7 @@ func traktorCues(trackID uint32, cs []traktorCue) []MasterDBCue {
 		if !isHot && c.Type != traktorCueTypeCue && c.Type != traktorCueTypeLoop {
 			continue
 		}
-		mc := MasterDBCue{
+		mc := ImportedCue{
 			TrackID: trackID,
 			HotCue:  -1,
 			TimeMs:  uint32(c.Start + 0.5),

--- a/library/import_traktor.go
+++ b/library/import_traktor.go
@@ -115,6 +115,19 @@ type traktorPrimaryKey struct {
 	Key  string `xml:"KEY,attr"`  // VOLUME+DIR+FILE location key
 }
 
+type traktorImporter struct{}
+
+func (traktorImporter) Label() string           { return "Traktor NML" }
+func (traktorImporter) Handles(p string) bool   { return hasExt(p, ".nml") }
+func (traktorImporter) RequiresKey(string) bool { return false }
+
+func (traktorImporter) Import(lib *Library, o ImportOptions) (*ImportBundle, error) {
+	if !o.WantTracks {
+		return &ImportBundle{}, nil
+	}
+	return ImportTraktorNML(lib, o.Path)
+}
+
 // ImportTraktorNML imports a Traktor collection.nml. Cues (hot cues, memory
 // cues, and loops from CUE_V2) come back in the bundle's ImportedCue carrier the
 // api.go applier already consumes; Traktor has no MyTags or per-track colours,

--- a/library/import_traktor_test.go
+++ b/library/import_traktor_test.go
@@ -64,10 +64,11 @@ func TestImportTraktorNML(t *testing.T) {
 	}
 
 	lib := NewLibrary(nil, nil)
-	res, playlists, tags, colors, cues, err := ImportTraktorNML(lib, nml)
+	bundle, err := ImportTraktorNML(lib, nml)
 	if err != nil {
 		t.Fatalf("import: %v", err)
 	}
+	res, playlists, tags, colors, cues := bundle.Result, bundle.Playlists, bundle.Tags, bundle.Colors, bundle.Cues
 	if tags != nil || colors != nil {
 		t.Errorf("expected nil tags/colors, got %v / %v", tags, colors)
 	}
@@ -109,7 +110,7 @@ func TestImportTraktorNML(t *testing.T) {
 	if len(cues) != 4 {
 		t.Fatalf("cues=%d want 4: %+v", len(cues), cues)
 	}
-	want := []MasterDBCue{
+	want := []ImportedCue{
 		{TrackID: tr.ID, HotCue: 1, TimeMs: 1000, LoopMs: -1, Comment: "Intro"},     // HOTCUE 0 → slot 1
 		{TrackID: tr.ID, HotCue: 3, TimeMs: 2000, LoopMs: -1, Comment: "Drop"},      // 2000.4 rounds down
 		{TrackID: tr.ID, HotCue: -1, TimeMs: 5000, LoopMs: -1, Comment: "Mem"},      // memory cue

--- a/library/import_xml.go
+++ b/library/import_xml.go
@@ -205,14 +205,14 @@ func nodeToImport(n *rbxmlNode, idMap map[string]uint32) PlaylistImport {
 // third is the MyTags extracted from track comments (empty unless the
 // export had the "Add MyTag to Comments" preference enabled); the fourth
 // is the track colour labels resolved from each TRACK's Colour attribute.
-func ImportRekordboxXML(lib *Library, xmlPath string) (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, error) {
+func ImportRekordboxXML(lib *Library, xmlPath string) (*ImportBundle, error) {
 	data, err := os.ReadFile(xmlPath)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("read xml: %w", err)
+		return nil, fmt.Errorf("read xml: %w", err)
 	}
 	var doc RekordboxXML
 	if err := xml.Unmarshal(data, &doc); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("parse xml: %w", err)
+		return nil, fmt.Errorf("parse xml: %w", err)
 	}
 	log.Printf("import: %s v%s, %d tracks declared",
 		doc.Product.Name, doc.Product.Version, doc.Collection.Entries)
@@ -269,7 +269,7 @@ func ImportRekordboxXML(lib *Library, xmlPath string) (*ImportResult, []Playlist
 	}
 	res.TagsTotal = len(tags)
 	lib.FinalizeBulk()
-	return res, imports, tags, colors, nil
+	return &ImportBundle{Result: res, Playlists: imports, Tags: tags, Colors: colors}, nil
 }
 
 // locationToPath converts a rekordbox XML Location ("file://localhost/...")

--- a/library/importer_rekordbox.go
+++ b/library/importer_rekordbox.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package library
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The rekordbox importers wrap the format-specific parse functions
+// (ImportRekordboxXML / ImportRekordboxMasterDB) with the Importer interface and
+// the shared asset/settings location logic. XML carries only tracks; the
+// master.db and backup-zip forms also surface the analysis, artwork, and
+// player/mixer settings that sit beside (or inside) them.
+
+// --- rekordbox XML ---
+
+type rekordboxXMLImporter struct{}
+
+func (rekordboxXMLImporter) Label() string           { return "rekordbox XML" }
+func (rekordboxXMLImporter) Handles(p string) bool   { return hasExt(p, ".xml") }
+func (rekordboxXMLImporter) RequiresKey(string) bool { return false }
+
+func (rekordboxXMLImporter) Import(lib *Library, o ImportOptions) (*ImportBundle, error) {
+	if !o.WantTracks {
+		return &ImportBundle{}, nil
+	}
+	return ImportRekordboxXML(lib, o.Path)
+}
+
+// --- rekordbox master.db ---
+
+type rekordboxDBImporter struct{}
+
+func (rekordboxDBImporter) Label() string           { return "rekordbox master.db" }
+func (rekordboxDBImporter) Handles(p string) bool   { return hasExt(p, ".db") }
+func (rekordboxDBImporter) RequiresKey(string) bool { return true }
+
+func (rekordboxDBImporter) Import(lib *Library, o ImportOptions) (*ImportBundle, error) {
+	b := &ImportBundle{}
+	if o.WantTracks {
+		var err error
+		b, err = ImportRekordboxMasterDB(lib, o.Path, o.Key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// A master.db still in its rekordbox library folder has its analysis
+	// (share/PIONEER/USBANLZ), artwork (share/PIONEER/Artwork), and *SETTING.DAT
+	// blobs right beside it — the same layout a backup zip mirrors — so surface
+	// them for the asset/settings import, making a bare-.db import nearly as
+	// complete as a .zip. (A db copied out on its own has no neighbours, so these
+	// stay empty and nothing extra is imported.)
+	dbDir := filepath.Dir(o.Path)
+	if fi, e := os.Stat(filepath.Join(dbDir, "share")); e == nil && fi.IsDir() {
+		b.ShareRoot = filepath.Join(dbDir, "share")
+	}
+	if o.WantSettings {
+		b.SettingsDir = findRekordboxSettingsDir(dbDir)
+	}
+	return b, nil
+}
+
+// --- rekordbox library backup (.zip) ---
+
+type rekordboxBackupImporter struct{}
+
+func (rekordboxBackupImporter) Label() string           { return "rekordbox backup" }
+func (rekordboxBackupImporter) Handles(p string) bool   { return hasExt(p, ".zip") }
+func (rekordboxBackupImporter) RequiresKey(string) bool { return true }
+
+func (rekordboxBackupImporter) Import(lib *Library, o ImportOptions) (*ImportBundle, error) {
+	// A rekordbox library backup bundles master.db, the share/PIONEER analysis &
+	// artwork trees, and the *SETTING.DAT blobs in one zip. Extract the parts we
+	// need to a temp dir, import the db, and hand the roots back for the apply
+	// pipeline; the temp dir is released via Cleanup once that has run.
+	tmp, err := os.MkdirTemp("", "rb-backup-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	o.note("Extracting backup…")
+	dbPath, shareRoot, settingsDir, err := extractRekordboxBackup(o.Path, tmp, o.WantSettings)
+	if err != nil {
+		os.RemoveAll(tmp)
+		return nil, fmt.Errorf("extract backup: %w", err)
+	}
+	b := &ImportBundle{}
+	if o.WantTracks {
+		o.note("Reading rekordbox database…")
+		b, err = ImportRekordboxMasterDB(lib, dbPath, o.Key)
+		if err != nil {
+			os.RemoveAll(tmp)
+			return nil, err
+		}
+	}
+	b.ShareRoot = shareRoot
+	b.SettingsDir = settingsDir
+	b.Cleanup = func() { os.RemoveAll(tmp) }
+	return b, nil
+}
+
+// rekordboxSettingsFiles are the player/mixer setting blobs rekordbox writes to
+// the root of a library-backup zip (and to /PIONEER on a USB export).
+var rekordboxSettingsFiles = []string{
+	"MYSETTING.DAT", "MYSETTING2.DAT", "DJMMYSETTING.DAT", "DEVSETTING.DAT",
+}
+
+// findRekordboxSettingsDir returns the directory holding *SETTING.DAT blobs for
+// a master.db in dbDir, or "" if none has them. rekordbox 6 keeps them in a
+// sibling "rekordbox6" folder (the db lives in "rekordbox"); a backup zip puts
+// them beside the db, so the sibling is checked first, then the db's own dir.
+func findRekordboxSettingsDir(dbDir string) string {
+	has := func(dir string) bool {
+		for _, sf := range rekordboxSettingsFiles {
+			if _, e := os.Stat(filepath.Join(dir, sf)); e == nil {
+				return true
+			}
+		}
+		return false
+	}
+	for _, cand := range []string{filepath.Join(filepath.Dir(dbDir), "rekordbox6"), dbDir} {
+		if has(cand) {
+			return cand
+		}
+	}
+	return ""
+}
+
+// extractRekordboxBackup unpacks the parts of a rekordbox library-backup zip we
+// care about — master.db, the share/PIONEER/{USBANLZ,Artwork} trees, and (when
+// wantSettings) the *SETTING.DAT blobs at the zip root — into dest. It returns
+// the extracted master.db path, the share/ root, and the directory holding the
+// settings files (empty if none were extracted). Other entries (lighting DBs,
+// XML prefs, etc.) are skipped. Guards against zip-slip.
+func extractRekordboxBackup(zipPath, dest string, wantSettings bool) (dbPath, shareRoot, settingsDir string, err error) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", "", "", err
+	}
+	defer zr.Close()
+
+	isSettingsFile := func(name string) bool {
+		for _, s := range rekordboxSettingsFiles {
+			if name == s {
+				return true
+			}
+		}
+		return false
+	}
+
+	cleanDest := filepath.Clean(dest)
+	gotSettings := false
+	for _, f := range zr.File {
+		name := f.Name // zip paths use forward slashes
+		settings := wantSettings && isSettingsFile(name)
+		keep := name == "master.db" ||
+			strings.HasPrefix(name, "share/PIONEER/USBANLZ/") ||
+			strings.HasPrefix(name, "share/PIONEER/Artwork/") ||
+			settings
+		if !keep || f.FileInfo().IsDir() {
+			continue
+		}
+		target := filepath.Join(cleanDest, filepath.FromSlash(name))
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+			continue // zip-slip: entry escapes dest
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return "", "", "", err
+		}
+		if err := extractZipEntry(f, target); err != nil {
+			return "", "", "", err
+		}
+		if settings {
+			gotSettings = true
+		}
+	}
+
+	dbPath = filepath.Join(cleanDest, "master.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		return "", "", "", fmt.Errorf("master.db not found in backup zip")
+	}
+	if gotSettings {
+		settingsDir = cleanDest
+	}
+	return dbPath, filepath.Join(cleanDest, "share"), settingsDir, nil
+}
+
+// extractZipEntry copies one zip file entry to target on disk.
+func extractZipEntry(f *zip.File, target string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	out, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, rc)
+	return err
+}

--- a/library/importer_test.go
+++ b/library/importer_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package library
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImporterRegistry(t *testing.T) {
+	cases := []struct {
+		path     string
+		label    string
+		needsKey bool
+	}{
+		{"/music/collection.nml", "Traktor NML", false},
+		{"/music/rekordbox.xml", "rekordbox XML", false},
+		{"/music/master.db", "rekordbox master.db", true},
+		{"/music/rekordbox_bak.zip", "rekordbox backup", true},
+		{"/music/RB.XML", "rekordbox XML", false}, // extension match is case-insensitive
+	}
+	for _, c := range cases {
+		imp := ImporterFor(c.path)
+		if imp == nil {
+			t.Errorf("%s: no importer", c.path)
+			continue
+		}
+		if imp.Label() != c.label {
+			t.Errorf("%s: label %q, want %q", c.path, imp.Label(), c.label)
+		}
+		if imp.RequiresKey(c.path) != c.needsKey {
+			t.Errorf("%s: RequiresKey=%v, want %v", c.path, imp.RequiresKey(c.path), c.needsKey)
+		}
+	}
+	if imp := ImporterFor("/music/song.mp3"); imp != nil {
+		t.Errorf("mp3 should have no importer, got %q", imp.Label())
+	}
+}
+
+// writeTestZip creates a zip at path whose entries are name→content.
+func writeTestZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractRekordboxBackup(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "backup.zip")
+	writeTestZip(t, zipPath, map[string]string{
+		"master.db":                          "db",
+		"share/PIONEER/USBANLZ/ANLZ0000.DAT": "anlz",
+		"share/PIONEER/Artwork/art.jpg":      "art",
+		"MYSETTING.DAT":                      "set",
+		"masterPlaylists6.xml":               "junk", // not one of the kept prefixes
+	})
+
+	dest := filepath.Join(dir, "out")
+	dbPath, shareRoot, settingsDir, err := extractRekordboxBackup(zipPath, dest, true)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if dbPath != filepath.Join(dest, "master.db") {
+		t.Errorf("dbPath=%q", dbPath)
+	}
+	if shareRoot != filepath.Join(dest, "share") {
+		t.Errorf("shareRoot=%q", shareRoot)
+	}
+	if settingsDir != dest {
+		t.Errorf("settingsDir=%q, want %q", settingsDir, dest)
+	}
+	// Kept entries exist; the junk entry was skipped.
+	for _, rel := range []string{"master.db", "share/PIONEER/USBANLZ/ANLZ0000.DAT", "MYSETTING.DAT"} {
+		if _, err := os.Stat(filepath.Join(dest, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("expected %s extracted: %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dest, "masterPlaylists6.xml")); !os.IsNotExist(err) {
+		t.Errorf("junk entry should have been skipped")
+	}
+
+	// wantSettings=false leaves settingsDir empty and skips the *SETTING.DAT.
+	dest2 := filepath.Join(dir, "out2")
+	_, _, settingsDir2, err := extractRekordboxBackup(zipPath, dest2, false)
+	if err != nil {
+		t.Fatalf("extract2: %v", err)
+	}
+	if settingsDir2 != "" {
+		t.Errorf("settingsDir2=%q, want empty", settingsDir2)
+	}
+	if _, err := os.Stat(filepath.Join(dest2, "MYSETTING.DAT")); !os.IsNotExist(err) {
+		t.Errorf("MYSETTING.DAT should not be extracted when wantSettings=false")
+	}
+}
+
+func TestExtractRekordboxBackupNoDB(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "nodb.zip")
+	writeTestZip(t, zipPath, map[string]string{"share/PIONEER/USBANLZ/x.DAT": "a"})
+	if _, _, _, err := extractRekordboxBackup(zipPath, filepath.Join(dir, "out"), true); err == nil {
+		t.Error("expected error when master.db is absent")
+	}
+}
+
+// The backup importer with WantTracks=false extracts assets/settings without
+// touching the (SQLCipher, python-only) db, and Cleanup releases the temp dir.
+func TestBackupImporterSettingsOnly(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "backup.zip")
+	writeTestZip(t, zipPath, map[string]string{
+		"master.db":                          "db",
+		"share/PIONEER/USBANLZ/ANLZ0000.DAT": "anlz",
+		"MYSETTING.DAT":                      "set",
+	})
+
+	b, err := rekordboxBackupImporter{}.Import(nil, ImportOptions{
+		Path: zipPath, WantTracks: false, WantSettings: true,
+	})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if b.Result != nil {
+		t.Errorf("WantTracks=false should leave Result nil, got %+v", b.Result)
+	}
+	if filepath.Base(b.ShareRoot) != "share" || b.SettingsDir == "" {
+		t.Errorf("ShareRoot=%q SettingsDir=%q", b.ShareRoot, b.SettingsDir)
+	}
+	if b.Cleanup == nil {
+		t.Fatal("expected a Cleanup func")
+	}
+	if _, err := os.Stat(b.ShareRoot); err != nil {
+		t.Errorf("share root should exist before cleanup: %v", err)
+	}
+	b.Cleanup()
+	if _, err := os.Stat(b.ShareRoot); !os.IsNotExist(err) {
+		t.Errorf("Cleanup should have removed the temp dir")
+	}
+}


### PR DESCRIPTION
## What & why

Adding a source library format currently means writing another format-specific function with its own return signature and adding another case to a growing switch in the import handler. This turns that into a small Importer registry: adding a format becomes "implement one interface and register it". It is groundwork for Serato / Engine / iTunes imports, and it leaves the existing rekordbox and Traktor imports behaving identically (this is a refactor, not a behaviour change).

Design write-up: docs/design/import-layer.md (separate doc PR).

Four phases, each a commit:

1. ImportBundle. The three importers (rekordbox XML, rekordbox master.db, Traktor NML) returned 4-, 6-, and 5-value tuples; they now all return (*ImportBundle, error), one neutral carrier for the side-data the applier materializes. The shared carriers are renamed MasterDBCue to ImportedCue and MasterDBAsset to ImportedAsset, since Traktor uses them too and the master.db name was misleading.

2. Importer interface + registry. library.Importer (Label / Handles / RequiresKey / Import) with ImportOptions (Path / Key / WantTracks / WantSettings / Progress) and an Importers() / ImporterFor() registry. The backup zip becomes a first-class delegating importer instead of handler-side special code: it owns extraction (extractRekordboxBackup / extractZipEntry / rekordboxSettingsFiles move from api to library) and hands its temp dir back via a bundle Cleanup func the handler defers once the apply pipeline has read ShareRoot / SettingsDir. The handler's format switch collapses to ImporterFor plus a key check plus Import(opts).

3. applyImportBundle. The roughly 350-line materialization pipeline (playlists, tags, colours, cues, analysis, artwork, settings, missing-file flagging, JSON summary) moves out of handleImportRekordbox into a dedicated s.applyImportBundle method, verbatim. The handler is now decode, resolve include flags, ImporterFor, key check, Import, applyImportBundle (roughly 190 fewer lines in the dispatch).

4. Drop the superseded core.Importer. The thin Tracks+Playlists core.Importer (and core.ImportOptions) from the initial core scaffolding is deleted; it was superseded by library.Importer, which carries the rich rekordbox-shaped side-data (tags, cues, colours, ANLZ assets, smart-playlist rules) real imports need. The export interfaces (core.Exporter, core.Library, core.ExportOptions) stay as placeholders for a future export-layer decision, which an import PR should not pre-empt.

Why the seam lives in library, not core: import inherently populates the concrete library.Library and carries side-data the neutral core.Importer never modelled. The apply pipeline was already format-agnostic, so it only had to be extracted, not rewritten.

One deliberate behaviour change: a malformed backup zip now surfaces as HTTP 500 ("import failed") rather than the previous 400. Key validation still happens up front (400) before any extraction, so the common error is unchanged.

Not in this PR: export generalization (a parallel Exporter in library) waits for a second export target, and the next format (Serato or Engine) is the first real customer of this interface.

## Hardware testing

- **Tested on:** N/A: no deck-facing change. This is a refactor of the import/parse code and the HTTP handler; it does not touch the protocol, the load path, or analysis output, and the data imported by the existing formats is unchanged.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
