### PR TITLE
web: declutter the import dialog and make progress prominent

### DIFF
--- a/api/web/index.html
+++ b/api/web/index.html
@@ -1616,13 +1616,17 @@
     font-size: 11px; color: var(--text2);
     min-height: 14px; margin-top: 4px;
   }
-  /* Import progress bar (shown while a rekordbox import runs). */
-  .imp-progress { margin-top: 10px; display: none; }
-  .imp-progress.show { display: block; }
-  .imp-progress-phase { font-size: 11px; color: var(--cyan); letter-spacing: 0.04em; margin-bottom: 6px; }
+  /* Import progress — takes over the dialog body while an import runs. */
+  .imp-progress { display: none; }
+  .imp-progress.show { display: block; padding: 30px 8px 22px; text-align: center; }
+  .imp-progress-phase {
+    font-size: 13px; color: var(--cyan); letter-spacing: 0.06em;
+    text-transform: uppercase; font-weight: 600; margin-bottom: 16px;
+  }
   .imp-progress-track {
-    height: 6px; background: #000; border: 1px solid var(--wire);
-    border-radius: 3px; overflow: hidden; position: relative;
+    height: 10px; background: #000; border: 1px solid var(--wire);
+    border-radius: 5px; overflow: hidden; position: relative;
+    max-width: 440px; margin: 0 auto;
   }
   .imp-progress-fill {
     height: 100%; width: 0%;
@@ -1636,9 +1640,21 @@
   }
   @keyframes imp-slide { 0% { left: -35%; } 100% { left: 100%; } }
   .imp-progress-count {
-    font-size: 10px; color: var(--text3); margin-top: 5px; text-align: right;
+    font-size: 11px; color: var(--text3); margin-top: 10px; text-align: center;
     font-variant-numeric: tabular-nums; min-height: 12px;
   }
+  /* Advanced-options disclosure in the import dialog. */
+  .imp-advanced { margin-top: 6px; border-top: 1px solid var(--wire); padding-top: 12px; }
+  .imp-advanced > summary {
+    cursor: pointer; list-style: none; user-select: none;
+    font-size: 11px; color: var(--text2); letter-spacing: 0.08em;
+    text-transform: uppercase; padding: 2px 0;
+  }
+  .imp-advanced > summary::-webkit-details-marker { display: none; }
+  .imp-advanced > summary::before { content: '▸ '; color: var(--text3); }
+  .imp-advanced[open] > summary::before { content: '▾ '; }
+  .imp-advanced > summary:hover { color: var(--orange); }
+  .imp-advanced .export-row:first-of-type { margin-top: 14px; }
   .menu-modal .foot #export-go {
     background: var(--orange-soft); color: var(--black); border-color: var(--orange);
     margin-left: auto;
@@ -10742,67 +10758,57 @@ function openImportRekordboxDialog() {
       <button class="x" type="button" title="Close">×</button>
     </div>
     <div class="body">
-      <div class="export-row">
-        <label class="export-label">Source</label>
-        <div class="export-radios imp-source">
-          <label><input type="radio" name="imp_src" value="xml" checked> XML export <span class="export-hint" style="display:inline">— no key required</span></label>
-          <label><input type="radio" name="imp_src" value="nml"> Traktor NML <span class="export-hint" style="display:inline">— collection.nml</span></label>
-          <label><input type="radio" name="imp_src" value="db"> master.db <span class="export-hint" style="display:inline">— needs 64-hex SQLCipher key</span></label>
-          <label><input type="radio" name="imp_src" value="zip"> Backup .zip <span class="export-hint" style="display:inline">— full: + waveforms, cues, artwork</span></label>
+      <div id="imp-form">
+        <div class="export-row">
+          <label class="export-label">Source</label>
+          <div class="export-radios imp-source">
+            <label><input type="radio" name="imp_src" value="xml" checked> rekordbox XML</label>
+            <label><input type="radio" name="imp_src" value="nml"> Traktor NML</label>
+            <label><input type="radio" name="imp_src" value="db"> rekordbox master.db</label>
+            <label><input type="radio" name="imp_src" value="zip"> rekordbox backup .zip</label>
+          </div>
+          <div class="export-hint" id="imp-src-hint"></div>
         </div>
-        <div class="export-hint">
-          In rekordbox: <b>File → Export Collection in XML</b> writes a .xml you can
-          import without any key. The master.db path requires the 64-hex SQLCipher key
-          that decrypts it (see the key field below). Point it at the
-          master.db <i>inside your rekordbox library folder</i> and it also pulls in the
-          waveforms, beat grids, cover art, and player/mixer settings sitting beside it;
-          a master.db copied out on its own brings metadata + cues only. A
-          <b>library backup .zip</b> (rekordbox's <b>File → Library → Backup</b>) bundles
-          the same thing in one file — and needs the same key. For <b>Traktor</b>,
-          point it at your <b>collection.nml</b> to bring in tracks, playlists, and
-          cues (no key required).
+        <div class="export-row">
+          <label class="export-label">Path</label>
+          <input type="text" id="imp-path" class="input" placeholder="/path/to/rekordbox.xml" autocomplete="off" spellcheck="false">
         </div>
-      </div>
-      <div class="export-row">
-        <label class="export-label">Path</label>
-        <input type="text" id="imp-path" class="input" placeholder="/path/to/rekordbox.xml" autocomplete="off" spellcheck="false">
-      </div>
-      <div class="export-row" id="imp-key-row" style="display:none">
-        <label class="export-label">SQLCipher key <span class="export-hint" style="display:inline">(required)</span></label>
-        <input type="text" id="imp-key" class="input" placeholder="64-hex SQLCipher key" autocomplete="off" spellcheck="false">
-        <div class="export-hint">
-          The <code>master.db</code> is encrypted. Paste the 64-hex SQLCipher key
-          for your own rekordbox database — rekordbox doesn't show it in its UI,
-          so recover it from your local rekordbox install, then paste it here.
+        <div class="export-row" id="imp-key-row" style="display:none">
+          <label class="export-label">SQLCipher key <span class="export-hint" style="display:inline">(required)</span></label>
+          <input type="text" id="imp-key" class="input" placeholder="64-hex SQLCipher key" autocomplete="off" spellcheck="false">
+          <div class="export-hint">rekordbox doesn't show this — recover it from your local install, then paste it here.</div>
         </div>
+        <details class="imp-advanced">
+          <summary>Advanced options</summary>
+          <div class="export-row">
+            <label class="export-label">Include</label>
+            <div id="imp-include" style="display:flex; flex-wrap:wrap; gap:6px 16px;">
+              <label data-src="xml,nml,db,zip"><input type="checkbox" id="inc-tracks" checked> Tracks</label>
+              <label data-src="xml,nml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-playlists" checked> Playlists</label>
+              <label data-src="xml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-tags" checked> Tags</label>
+              <label data-src="nml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-cues" checked> Cues</label>
+              <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-analysis" checked> Waveforms &amp; beat grids</label>
+              <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-artwork" checked> Artwork</label>
+              <label data-src="db,zip"><input type="checkbox" id="inc-settings" checked> Player/mixer settings</label>
+            </div>
+            <div class="export-hint">Derived options (playlists, tags, cues, analysis, artwork) need Tracks.</div>
+          </div>
+          <div class="export-row">
+            <label class="export-label">Path remap</label>
+            <div style="display:flex; gap:6px;">
+              <input type="text" id="imp-from" class="input" placeholder="From: Z:/Music/" autocomplete="off" spellcheck="false" style="flex:1">
+              <input type="text" id="imp-to"   class="input" placeholder="To: /media/usb/Music/" autocomplete="off" spellcheck="false" style="flex:1">
+            </div>
+            <div class="export-hint">Rewrites any track path starting with the From prefix.</div>
+          </div>
+        </details>
       </div>
-      <div class="export-row">
-        <label class="export-label">Path remap <span class="export-hint" style="display:inline">(optional)</span></label>
-        <div style="display:flex; gap:6px;">
-          <input type="text" id="imp-from" class="input" placeholder="From prefix: Z:/Music/" autocomplete="off" spellcheck="false" style="flex:1">
-          <input type="text" id="imp-to"   class="input" placeholder="To prefix: /media/usb/Music/" autocomplete="off" spellcheck="false" style="flex:1">
-        </div>
-        <div class="export-hint">Rewrites any track path starting with the From prefix. Leave blank to import paths as-is.</div>
-      </div>
-      <div class="export-row">
-        <label class="export-label">Include</label>
-        <div id="imp-include" style="display:flex; flex-wrap:wrap; gap:6px 16px;">
-          <label data-src="xml,nml,db,zip"><input type="checkbox" id="inc-tracks" checked> Tracks <span class="export-hint" style="display:inline">— incl. rating, colour, key</span></label>
-          <label data-src="xml,nml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-playlists" checked> Playlists</label>
-          <label data-src="xml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-tags" checked> Tags</label>
-          <label data-src="nml,db,zip" data-dep="tracks"><input type="checkbox" id="inc-cues" checked> Cues</label>
-          <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-analysis" checked> Waveforms &amp; beat grids</label>
-          <label data-src="db,zip" data-dep="tracks"><input type="checkbox" id="inc-artwork" checked> Artwork</label>
-          <label data-src="db,zip"><input type="checkbox" id="inc-settings" checked> Player/mixer settings</label>
-        </div>
-        <div class="export-hint">Uncheck anything you don't want. Options the chosen source can't provide are hidden. (Playlists, tags, cues, analysis and artwork all require Tracks.)</div>
-      </div>
-      <div class="export-status" id="imp-status"></div>
       <div class="imp-progress" id="imp-progress">
         <div class="imp-progress-phase" id="imp-prog-phase"></div>
         <div class="imp-progress-track"><div class="imp-progress-fill" id="imp-prog-fill"></div></div>
         <div class="imp-progress-count" id="imp-prog-count"></div>
       </div>
+      <div class="export-status" id="imp-status"></div>
     </div>
     <div class="foot">
       <button type="button" id="imp-go">IMPORT</button>
@@ -10821,6 +10827,13 @@ function openImportRekordboxDialog() {
   const statusEl   = m.querySelector('#imp-status');
   const goBtn      = m.querySelector('#imp-go');
   const srcRadios  = m.querySelectorAll('input[name="imp_src"]');
+  const srcHint    = m.querySelector('#imp-src-hint');
+  const SRC_HINTS = {
+    xml: 'rekordbox → File → Export Collection in XML. Metadata + playlists, no key needed.',
+    nml: "Traktor's collection.nml — tracks, playlists, and cues. No key needed.",
+    db:  'The master.db inside your rekordbox library folder (also pulls in waveforms, artwork, and settings). Needs the SQLCipher key.',
+    zip: 'rekordbox → File → Library → Backup. Everything in one file. Needs the SQLCipher key.',
+  };
 
   const incTracksCb = m.querySelector('#inc-tracks');
   // Derived options (everything that needs the track import) are disabled when
@@ -10848,6 +10861,7 @@ function openImportRekordboxDialog() {
       keyRow.style.display = 'none';
       pathInput.placeholder = '/path/to/rekordbox.xml';
     }
+    srcHint.textContent = SRC_HINTS[src] || '';
     // Show only the include options this source can actually provide.
     m.querySelectorAll('#imp-include label[data-src]').forEach(lab => {
       const ok = lab.getAttribute('data-src').split(',').includes(src);
@@ -10894,9 +10908,8 @@ function openImportRekordboxDialog() {
       return;
     }
     goBtn.disabled = true;
-    pathInput.disabled = true;
-    keyInput.disabled = true;
     statusEl.textContent = '';
+    m.querySelector('#imp-form').style.display = 'none'; // swap the form out for the progress panel
     const stopProgress = startImportProgress(m);
     try {
       const r = await fetch('/api/import/rekordbox', {
@@ -10906,8 +10919,9 @@ function openImportRekordboxDialog() {
       stopProgress();
       if (!r.ok) {
         const t = await r.text();
+        m.querySelector('#imp-form').style.display = '';
         statusEl.textContent = `Failed: ${r.status} ${t}`;
-        goBtn.disabled = false; pathInput.disabled = false; keyInput.disabled = false;
+        goBtn.disabled = false;
         return;
       }
       const res = await r.json();
@@ -10933,8 +10947,9 @@ function openImportRekordboxDialog() {
       refreshLibraryView();
     } catch (err) {
       stopProgress();
+      m.querySelector('#imp-form').style.display = '';
       statusEl.textContent = `Failed: ${err}`;
-      goBtn.disabled = false; pathInput.disabled = false; keyInput.disabled = false;
+      goBtn.disabled = false;
     }
   };
 }

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -1591,16 +1591,16 @@
   }
   .export-radios input[type="radio"] { accent-color: var(--orange); }
   /* Import-dialog source picker: stacked, selectable cards. */
-  .export-radios.imp-source { flex-direction: column; gap: 8px; }
-  .export-radios.imp-source label {
-    display: flex; align-items: baseline; gap: 8px;
-    font-size: 12px; padding: 8px 10px;
-    border: 1px solid var(--wire); border-radius: 6px;
-    transition: border-color 0.12s, background 0.12s;
+  /* Import: system picker (top-level) — a horizontal row of ecosystem tabs. */
+  .imp-systems { display: flex; gap: 8px; }
+  .imp-systems button {
+    flex: 1; font: inherit; font-size: 12px; padding: 10px 12px;
+    background: transparent; color: var(--text2);
+    border: 1px solid var(--wire); border-radius: 6px; cursor: pointer;
+    transition: border-color 0.12s, background 0.12s, color 0.12s;
   }
-  .export-radios.imp-source label:hover { border-color: var(--orange); background: rgba(255,119,20,0.04); }
-  .export-radios.imp-source label:has(input:checked) { border-color: var(--orange); background: rgba(255,119,20,0.07); }
-  .export-radios.imp-source .export-hint { margin-top: 0; }
+  .imp-systems button:hover { border-color: var(--orange); color: var(--text); }
+  .imp-systems button.on { border-color: var(--orange); background: rgba(255,119,20,0.10); color: var(--text); }
   /* Add-from-folder browser */
   .fs-crumb { font-size: 11px; color: var(--text2); margin-bottom: 8px; word-break: break-all; }
   .fs-list { max-height: 340px; overflow-y: auto; border: 1px solid var(--wire); border-radius: 6px; }
@@ -10760,15 +10760,14 @@ function openImportRekordboxDialog() {
     <div class="body">
       <div id="imp-form">
         <div class="export-row">
-          <label class="export-label">Source</label>
-          <div class="export-radios imp-source">
-            <label><input type="radio" name="imp_src" value="xml" checked> rekordbox XML</label>
-            <label><input type="radio" name="imp_src" value="nml"> Traktor NML</label>
-            <label><input type="radio" name="imp_src" value="db"> rekordbox master.db</label>
-            <label><input type="radio" name="imp_src" value="zip"> rekordbox backup .zip</label>
-          </div>
-          <div class="export-hint" id="imp-src-hint"></div>
+          <label class="export-label">System</label>
+          <div class="imp-systems" id="imp-systems"></div>
         </div>
+        <div class="export-row" id="imp-format-row" style="display:none">
+          <label class="export-label">Format</label>
+          <div class="export-radios imp-formats" id="imp-formats"></div>
+        </div>
+        <div class="export-hint" id="imp-src-hint"></div>
         <div class="export-row">
           <label class="export-label">Path</label>
           <input type="text" id="imp-path" class="input" placeholder="/path/to/rekordbox.xml" autocomplete="off" spellcheck="false">
@@ -10826,14 +10825,29 @@ function openImportRekordboxDialog() {
   const keyRow     = m.querySelector('#imp-key-row');
   const statusEl   = m.querySelector('#imp-status');
   const goBtn      = m.querySelector('#imp-go');
-  const srcRadios  = m.querySelectorAll('input[name="imp_src"]');
   const srcHint    = m.querySelector('#imp-src-hint');
-  const SRC_HINTS = {
-    xml: 'rekordbox → File → Export Collection in XML. Metadata + playlists, no key needed.',
-    nml: "Traktor's collection.nml — tracks, playlists, and cues. No key needed.",
-    db:  'The master.db inside your rekordbox library folder (also pulls in waveforms, artwork, and settings). Needs the SQLCipher key.',
-    zip: 'rekordbox → File → Library → Backup. Everything in one file. Needs the SQLCipher key.',
-  };
+  const systemsEl  = m.querySelector('#imp-systems');
+  const formatRow  = m.querySelector('#imp-format-row');
+  const formatsEl  = m.querySelector('#imp-formats');
+
+  // Import sources grouped by DJ system. Each format's id (xml/nml/db/zip) is
+  // what the include-filter data-src and the request logic key off; a system
+  // with a single format skips the Format row and goes straight to the path.
+  const SYSTEMS = [
+    { id: 'rekordbox', label: 'Rekordbox', formats: [
+      { id: 'xml', label: 'XML',            needsKey: false, placeholder: '/path/to/rekordbox.xml',
+        hint: 'rekordbox → File → Export Collection in XML. Metadata + playlists, no key needed.' },
+      { id: 'db',  label: 'master.db',      needsKey: true,  placeholder: '/path/to/master.db',
+        hint: 'The master.db inside your rekordbox library folder (also pulls in waveforms, artwork, and settings). Needs the SQLCipher key.' },
+      { id: 'zip', label: 'backup .zip',    needsKey: true,  placeholder: '/path/to/rekordbox_bak_YYYYMMDD.zip',
+        hint: 'rekordbox → File → Library → Backup. Everything in one file. Needs the SQLCipher key.' },
+    ]},
+    { id: 'traktor', label: 'Traktor', formats: [
+      { id: 'nml', label: 'collection.nml', needsKey: false, placeholder: '/path/to/collection.nml',
+        hint: "Traktor's collection.nml — tracks, playlists, and cues. No key needed." },
+    ]},
+  ];
+  let curFormat = SYSTEMS[0].formats[0]; // the selected format object
 
   const incTracksCb = m.querySelector('#inc-tracks');
   // Derived options (everything that needs the track import) are disabled when
@@ -10846,40 +10860,44 @@ function openImportRekordboxDialog() {
       lab.style.opacity = on ? '' : '0.4';
     });
   };
-  const syncSource = () => {
-    const src = m.querySelector('input[name="imp_src"]:checked').value;
-    if (src === 'db') {
-      keyRow.style.display = '';
-      pathInput.placeholder = '/path/to/master.db';
-    } else if (src === 'zip') {
-      keyRow.style.display = '';
-      pathInput.placeholder = '/path/to/rekordbox_bak_YYYYMMDD.zip';
-    } else if (src === 'nml') {
-      keyRow.style.display = 'none';
-      pathInput.placeholder = '/path/to/collection.nml';
-    } else {
-      keyRow.style.display = 'none';
-      pathInput.placeholder = '/path/to/rekordbox.xml';
-    }
-    srcHint.textContent = SRC_HINTS[src] || '';
-    // Show only the include options this source can actually provide.
+  // Apply the chosen format: key field, path placeholder, hint, and which
+  // Include options the format can provide.
+  const applyFormat = (fmt) => {
+    curFormat = fmt;
+    keyRow.style.display = fmt.needsKey ? '' : 'none';
+    pathInput.placeholder = fmt.placeholder;
+    srcHint.textContent = fmt.hint;
     m.querySelectorAll('#imp-include label[data-src]').forEach(lab => {
-      const ok = lab.getAttribute('data-src').split(',').includes(src);
-      lab.style.display = ok ? '' : 'none';
+      lab.style.display = lab.getAttribute('data-src').split(',').includes(fmt.id) ? '' : 'none';
     });
     syncIncludeDeps();
   };
+  // Select a system: highlight its tab, render its Format radios (only when it
+  // has more than one), and apply its first format.
+  const selectSystem = (sys) => {
+    systemsEl.querySelectorAll('button').forEach(b => b.classList.toggle('on', b.dataset.sys === sys.id));
+    const multi = sys.formats.length > 1;
+    formatRow.style.display = multi ? '' : 'none';
+    formatsEl.innerHTML = multi ? sys.formats.map((f, i) =>
+      `<label><input type="radio" name="imp_fmt" value="${f.id}"${i === 0 ? ' checked' : ''}> ${f.label}</label>`).join('') : '';
+    formatsEl.querySelectorAll('input').forEach(r => {
+      r.onchange = () => applyFormat(sys.formats.find(f => f.id === r.value));
+    });
+    applyFormat(sys.formats[0]);
+  };
+  systemsEl.innerHTML = SYSTEMS.map(s => `<button type="button" data-sys="${s.id}">${s.label}</button>`).join('');
+  systemsEl.querySelectorAll('button').forEach(b => {
+    b.onclick = () => selectSystem(SYSTEMS.find(s => s.id === b.dataset.sys));
+  });
   incTracksCb.onchange = syncIncludeDeps;
-  srcRadios.forEach(r => r.onchange = syncSource);
-  syncSource();
+  selectSystem(SYSTEMS[0]);
   pathInput.focus();
 
   goBtn.onclick = async () => {
-    const src  = m.querySelector('input[name="imp_src"]:checked').value;
     const path = pathInput.value.trim();
     if (!path) { statusEl.textContent = 'Path is required.'; return; }
     const body = { path };
-    if (src === 'db' || src === 'zip') {
+    if (curFormat.needsKey) {
       const k = keyInput.value.trim().toLowerCase().replace(/^0x/, '');
       if (!/^[0-9a-f]{64}$/.test(k)) {
         statusEl.textContent = 'A 64-hex SQLCipher key is required.';

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -1591,16 +1591,26 @@
   }
   .export-radios input[type="radio"] { accent-color: var(--orange); }
   /* Import-dialog source picker: stacked, selectable cards. */
-  /* Import: system + format pickers — horizontal rows of select buttons. */
-  .imp-systems, .imp-formats { display: flex; gap: 8px; }
-  .imp-systems button, .imp-formats button {
+  /* Import: system picker (top-level) — prominent full-width ecosystem tabs. */
+  .imp-systems { display: flex; gap: 8px; }
+  .imp-systems button {
     flex: 1; font: inherit; font-size: 12px; padding: 10px 12px;
     background: transparent; color: var(--text2);
     border: 1px solid var(--wire); border-radius: 6px; cursor: pointer;
     transition: border-color 0.12s, background 0.12s, color 0.12s;
   }
-  .imp-systems button:hover, .imp-formats button:hover { border-color: var(--orange); color: var(--text); }
-  .imp-systems button.on, .imp-formats button.on { border-color: var(--orange); background: rgba(255,119,20,0.10); color: var(--text); }
+  .imp-systems button:hover { border-color: var(--orange); color: var(--text); }
+  .imp-systems button.on { border-color: var(--orange); background: rgba(255,119,20,0.10); color: var(--text); }
+  /* Import: format picker (secondary) — lighter, content-sized pills. */
+  .imp-formats { display: flex; gap: 6px; flex-wrap: wrap; }
+  .imp-formats button {
+    font: inherit; font-size: 11px; padding: 6px 11px;
+    background: transparent; color: var(--text3);
+    border: 1px solid var(--wire); border-radius: 5px; cursor: pointer;
+    transition: border-color 0.12s, background 0.12s, color 0.12s;
+  }
+  .imp-formats button:hover { border-color: var(--orange); color: var(--text2); }
+  .imp-formats button.on { border-color: var(--orange); color: var(--text); background: rgba(255,119,20,0.06); }
   /* Add-from-folder browser */
   .fs-crumb { font-size: 11px; color: var(--text2); margin-bottom: 8px; word-break: break-all; }
   .fs-list { max-height: 340px; overflow-y: auto; border: 1px solid var(--wire); border-radius: 6px; }
@@ -1660,6 +1670,7 @@
     margin-left: auto;
   }
   .menu-modal .foot #export-go:disabled { opacity: 0.5; cursor: not-allowed; }
+  .menu-modal .foot #imp-go { margin-left: auto; }
   .menu-modal .body .hint, .menu-config .hint {
     color: var(--text3); font-size: 10px; letter-spacing: 0.06em;
     margin-bottom: 10px;

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -1591,16 +1591,16 @@
   }
   .export-radios input[type="radio"] { accent-color: var(--orange); }
   /* Import-dialog source picker: stacked, selectable cards. */
-  /* Import: system picker (top-level) — a horizontal row of ecosystem tabs. */
-  .imp-systems { display: flex; gap: 8px; }
-  .imp-systems button {
+  /* Import: system + format pickers — horizontal rows of select buttons. */
+  .imp-systems, .imp-formats { display: flex; gap: 8px; }
+  .imp-systems button, .imp-formats button {
     flex: 1; font: inherit; font-size: 12px; padding: 10px 12px;
     background: transparent; color: var(--text2);
     border: 1px solid var(--wire); border-radius: 6px; cursor: pointer;
     transition: border-color 0.12s, background 0.12s, color 0.12s;
   }
-  .imp-systems button:hover { border-color: var(--orange); color: var(--text); }
-  .imp-systems button.on { border-color: var(--orange); background: rgba(255,119,20,0.10); color: var(--text); }
+  .imp-systems button:hover, .imp-formats button:hover { border-color: var(--orange); color: var(--text); }
+  .imp-systems button.on, .imp-formats button.on { border-color: var(--orange); background: rgba(255,119,20,0.10); color: var(--text); }
   /* Add-from-folder browser */
   .fs-crumb { font-size: 11px; color: var(--text2); margin-bottom: 8px; word-break: break-all; }
   .fs-list { max-height: 340px; overflow-y: auto; border: 1px solid var(--wire); border-radius: 6px; }
@@ -10765,7 +10765,7 @@ function openImportRekordboxDialog() {
         </div>
         <div class="export-row" id="imp-format-row" style="display:none">
           <label class="export-label">Format</label>
-          <div class="export-radios imp-formats" id="imp-formats"></div>
+          <div class="imp-formats" id="imp-formats"></div>
         </div>
         <div class="export-hint" id="imp-src-hint"></div>
         <div class="export-row">
@@ -10864,6 +10864,7 @@ function openImportRekordboxDialog() {
   // Include options the format can provide.
   const applyFormat = (fmt) => {
     curFormat = fmt;
+    formatsEl.querySelectorAll('button').forEach(b => b.classList.toggle('on', b.dataset.fmt === fmt.id));
     keyRow.style.display = fmt.needsKey ? '' : 'none';
     pathInput.placeholder = fmt.placeholder;
     srcHint.textContent = fmt.hint;
@@ -10878,10 +10879,10 @@ function openImportRekordboxDialog() {
     systemsEl.querySelectorAll('button').forEach(b => b.classList.toggle('on', b.dataset.sys === sys.id));
     const multi = sys.formats.length > 1;
     formatRow.style.display = multi ? '' : 'none';
-    formatsEl.innerHTML = multi ? sys.formats.map((f, i) =>
-      `<label><input type="radio" name="imp_fmt" value="${f.id}"${i === 0 ? ' checked' : ''}> ${f.label}</label>`).join('') : '';
-    formatsEl.querySelectorAll('input').forEach(r => {
-      r.onchange = () => applyFormat(sys.formats.find(f => f.id === r.value));
+    formatsEl.innerHTML = multi ? sys.formats.map(f =>
+      `<button type="button" data-fmt="${f.id}">${f.label}</button>`).join('') : '';
+    formatsEl.querySelectorAll('button').forEach(b => {
+      b.onclick = () => applyFormat(sys.formats.find(f => f.id === b.dataset.fmt));
     });
     applyFormat(sys.formats[0]);
   };


### PR DESCRIPTION
## What & why

The import popup had grown cluttered: four source radios (each with an inline hint) sat above a 12-line explanatory paragraph, then seven always-visible Include checkboxes, a path-remap row, and several more help paragraphs. The essentials (pick a source, point at a file, import) were buried under advanced options and help text.

Declutter via progressive disclosure:

- Source selection becomes two levels: a horizontal System picker (Rekordbox, Traktor) and, for a multi-format system, a Format sub-selection (rekordbox: XML / master.db / backup .zip). A single-format system (Traktor) skips the Format row and goes straight to the path. Sources are a SYSTEMS data table, so adding an ecosystem (Serato, Engine, VirtualDJ, M3U) is a data-entry change rather than another entry in a growing flat list.
- A single dynamic one-line hint describes the selected format (replacing the old 12-line paragraph).
- Include options and Path remap move into a collapsed "Advanced options" <details> disclosure, so the default view is System -> (Format) -> Path (-> Key when the format needs one).
- The key and remap help text is trimmed to one line each.

Nothing changes on the wire: the selected format's id still drives the key field, placeholder, and Advanced include-filtering, and the request body is unchanged.

Make the import progress prominent: on IMPORT the form is swapped out for the progress panel, which is now a centred, padded, uppercase phase label over a taller bar with a centred count, instead of a thin strip tucked under the form. Both error paths restore the form so the user can correct the path/key and retry.

No API or behaviour change: the same request is sent, the same include options exist (now under Advanced), and the same progress endpoint drives the bar.

## Hardware testing

- **Tested on:** N/A: web UI only. No change to the protocol, load path, analysis, or anything a deck reacts to.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
