### PR TITLE
web: drop the POLLING 1HZ and API-URL status-bar items

### DIFF
--- a/api/web/index.html
+++ b/api/web/index.html
@@ -3494,8 +3494,6 @@
 </aside>
 
 <div class="statusbar">
-  <span class="item"><span class="led green pulse"></span>POLLING 1HZ</span>
-  <span class="item" id="api-info">API ·</span>
   <span class="item" id="server-status" style="display:none"><span class="led"></span><span class="server-status-text"></span></span>
   <span class="spacer"></span>
   <span class="item" id="wave-color-btn" title="Web waveform colour — click to cycle. AUTO follows the CDJ 'waveform color' DEVSETTING." style="cursor:pointer; user-select:none"><span class="led green"></span><span id="wave-color-label">WAVE: AUTO</span></span>
@@ -3510,7 +3508,6 @@
 
 // ───────── boot ─────────
 const STARTED = Date.now();
-document.getElementById('api-info').textContent = 'API · http://' + location.host;
 
 // tabs
 document.querySelectorAll('.tab').forEach(t => {


### PR DESCRIPTION
## What & why

The bottom status bar carried two items that added noise without earning their place: a "POLLING 1HZ" indicator (the poll cadence is an implementation detail, not something a user acts on) and an "API · http://<host>" label (the address is already in the browser's URL bar). Removing both leaves the status bar to lead with the server-status chip and the actionable WAVE / VOCAL / LINK controls.

Just the two spans and the one line of JS that populated the API label; no other behaviour changes.

## Hardware testing

- **Tested on:** N/A: web UI only. No change to the protocol, load path, analysis, or anything a deck reacts to.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`) — n/a, no new files
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
