### PR TITLE
docs/design: import-layer plan + modular-backends reconciliation

### DIFF
--- a/docs/design/import-layer.md
+++ b/docs/design/import-layer.md
@@ -1,0 +1,142 @@
+# Generalizing the library import layer
+
+- **Status:** Proposed
+- **Scope:** refactor / library import
+- **Related:** [modular-backends.md](modular-backends.md) (this is the pragmatic,
+  import-only slice of that doc's "format adapters" idea)
+
+## Goal
+
+Make adding a new source library format (Serato, Engine, iTunes, ...) a matter of
+*implementing one interface and registering it*, instead of adding another
+divergent function plus another `case` to a growing switch. We now have three
+importers (rekordbox XML, rekordbox master.db, Traktor NML) plus the backup-zip
+container, which is the rule-of-three that justifies the abstraction. It would
+have been premature at one.
+
+Non-goal: neutralizing the *result* into `core` types. Import inherently
+populates `library.Library`; a brand-neutral import buys nothing until there is a
+non-library consumer. This lives in `library`.
+
+## Current shape
+
+Three parse functions with divergent signatures, dispatched by `switch ext` in
+`api.handleImportRekordbox`:
+
+```
+ImportRekordboxXML      -> (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, error)
+ImportRekordboxMasterDB -> (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, []MasterDBAsset, []MasterDBCue, error)
+ImportTraktorNML        -> (*ImportResult, []PlaylistImport, []TagImport, []ColorImport, []MasterDBCue, error)
+```
+
+Observations:
+
+- The `.zip` case is already a *delegating importer*: extract the backup, call
+  the master.db importer with the extracted `dbPath`, set `shareRoot` /
+  `settingsDir`.
+- After dispatch there is a ~350-line **format-agnostic apply pipeline**:
+  materialize the playlist tree (incl. smart playlists), tags + MyTag
+  categories, colors, ANLZ analysis + artwork from `assets`/`shareRoot`, cues
+  (ANLZ first, then the `masterCues` fallback), settings from `settingsDir`,
+  missing-file flagging, path remap, save, summary response. It consumes nothing
+  but the union of the return slices and the include flags.
+- `core.Importer` exists (Tracks + Playlists only), is unused, and does not fit
+  this reality.
+
+So the divergence is entirely in the **return signatures and the switch**. The
+apply side is already generic. A bundle + interface is what cleans up the rest.
+
+## Proposed design (all in `library`)
+
+A single neutral result carrier every importer returns:
+
+```go
+type ImportBundle struct {
+    Result      *ImportResult
+    Playlists   []PlaylistImport
+    Tags        []TagImport
+    Colors      []ColorImport
+    Cues        []ImportedCue    // renamed from MasterDBCue
+    Assets      []ImportedAsset  // renamed from MasterDBAsset
+    ShareRoot   string           // ANLZ/artwork root (zip extract, or the db's folder)
+    SettingsDir string           // *SETTING.DAT dir
+}
+
+type ImportOptions struct {
+    Path     string
+    Key      string             // decryption key where required (master.db / zip)
+    Include  ImportInclude      // tracks, playlists, tags, cues, analysis, artwork, settings
+    Progress func(msg string)   // importer -> UI phase updates ("Extracting backup...")
+}
+
+type Importer interface {
+    Label() string              // "rekordbox XML", "Traktor NML"
+    Handles(path string) bool   // by extension
+    RequiresKey(path string) bool
+    Import(lib *Library, opt ImportOptions) (*ImportBundle, error)
+}
+```
+
+A tiny registry:
+
+```go
+func Importers() []Importer            // rekordboxXML, rekordboxDB, rekordboxBackup, traktorNML
+func ImporterFor(path string) Importer // first whose Handles(path) is true, else nil
+```
+
+The backup zip becomes a first-class `Importer` that extracts and then delegates
+to the master.db importer, filling `ShareRoot` / `SettingsDir` on the bundle.
+
+The whole `switch` in `api.go` collapses to:
+
+```go
+imp := library.ImporterFor(req.Path)
+if imp == nil { /* 400: unsupported format */ }
+if imp.RequiresKey(req.Path) && !isHex64(key) { /* 400: key required */ }
+bundle, err := imp.Import(s.Library, opts)
+if err != nil { /* 500 */ }
+s.applyImportBundle(bundle, inc)   // the existing apply pipeline, extracted verbatim
+```
+
+Adding format #4 = implement `Importer`, append to the registry, add a UI radio.
+The `applyImportBundle` method and the dialog's include-options stay untouched.
+
+## Decisions
+
+1. **Package `library`, not `core`.** Delete the dead `core.Importer` rather than
+   force-fit it. Revisit only if a non-library consumer ever appears.
+2. **Rename `MasterDB{Cue,Asset}` -> `Imported{Cue,Asset}`.** They are the shared
+   carrier now that Traktor uses them; the rekordbox-era name is misleading.
+   Small blast radius (the two library files + the api.go applier).
+3. **Extract the ~350-line apply pipeline into `applyImportBundle`.** Pure move,
+   no logic change; slims the 530-line handler and benefits every importer
+   equally.
+4. **Progress callback in `ImportOptions`.** The zip importer needs to emit
+   "Extracting backup..."; today that lives in the handler. A `Progress func`
+   keeps phase reporting with the importer that knows the phases.
+
+## Phased plan (each phase builds green, no behavior change)
+
+1. Introduce `ImportBundle`; change the three importers to return
+   `(*ImportBundle, error)`; the switch fills a bundle. Rename the cue/asset
+   types here.
+2. Add the `Importer` interface + registry; wrap each importer; collapse the
+   switch to `ImporterFor`. The zip case becomes a delegating `Importer`.
+3. Extract the apply pipeline into `s.applyImportBundle`.
+4. Delete `core.Importer`.
+
+## Risk
+
+Local file parsing + HTTP wiring only. No serving path, no cache format, no
+hardware. Unlike the deferred part-3d flow-flip, this needs no CDJ smoke test;
+the existing importer unit tests plus a green `library`/`api`/`dbserver` suite
+cover it.
+
+## Not now
+
+- **Export.** A parallel `Exporter` interface + `ExportBundle` is the obvious
+  follow-up, but the export side (rekordbox USB/PDB) is a single implementation
+  today, so it has not hit rule-of-three. Do it when a second export target
+  (Engine, M3U) lands.
+- **Format #4.** Serato or Engine is the first real customer of this interface,
+  and the reason to build it.

--- a/docs/design/modular-backends.md
+++ b/docs/design/modular-backends.md
@@ -1,7 +1,27 @@
 # Modular backends: a brand-neutral core
 
-- **Status:** Proposed
+- **Status:** Partly implemented; sequence reprioritized (see Status)
 - **Scope:** architecture / refactor
+- **Related:** [import-layer.md](import-layer.md) — refines/reprioritizes step 5
+
+## Status (2026-07)
+
+Steps 1–2 have shipped: `core` exists, and `analysis` is split into pure DSP
+(`core.Analysis`) plus the Pioneer encoders under `link/prolink`. The rest has
+been **reordered** from the sequence below:
+
+- **3d (neutral analysis cache / encode-on-serve)** and **steps 3–4** (move
+  device/dbserver under `link/prolink`, define `core.Backend`, decouple `api`)
+  are **deferred**: they change the live serving path and only pay off with a
+  second protocol, which can't be validated without Denon/StageLinq hardware.
+- **Step 5 (library formats)** was **pulled forward** and is the productive axis
+  now — Traktor import has shipped. Its design lives in
+  [import-layer.md](import-layer.md), which **revises this doc on one point**:
+  the import adapter lands in `library` (`library.Importer` + `ImportBundle`),
+  not `core`, because real imports carry rich rekordbox-shaped side-data (tags,
+  cues, colours, ANLZ assets, smart-playlist rules) the thin `core.Importer`
+  never modelled. That thin `core.Importer` from step 1 is slated for deletion;
+  it can be lifted back to `core` if a non-library consumer ever appears.
 
 ## Goal
 
@@ -97,15 +117,16 @@ imports `core` only.
 ## Migration order (each a shippable PR; 1–4 are pure refactors)
 
 1. **Introduce `core`** with the model types + interfaces (this doc's PR). Purely
-   additive — nothing imports it yet, zero behavior change.
+   additive — nothing imports it yet, zero behavior change. **✅ done.**
 2. **Split `analysis`** into DSP (→ `core.Analysis`) vs encoders (→ `anlz`).
-   Highest-value cleanup; unblocks everything.
-3. **Move `proto/device/dbserver/nfs/pdb` under `link/prolink`**, define + implement `core.Backend`.
-4. **Decouple `api`** from `device`/`dbserver` via `core` interfaces.
-5. **Extract `format/rekordbox`** behind `Importer`/`Exporter`.
-6. `stagelinq` spike + `format/engine` slot in with no core changes.
+   Highest-value cleanup; unblocks everything. **✅ done** (encoders now under `link/prolink`).
+3. **Move `proto/device/dbserver/nfs/pdb` under `link/prolink`**, define + implement `core.Backend`. **⏸ deferred** (see Status).
+4. **Decouple `api`** from `device`/`dbserver` via `core` interfaces. **⏸ deferred.**
+5. **Extract library formats** behind `Importer`/`Exporter`. **➡️ in progress** as `library.Importer` — see [import-layer.md](import-layer.md).
+6. `stagelinq` spike + `format/engine` slot in with no core changes. **⬜ future.**
 
-Steps 1–4 are pure refactors — no new features, fully testable against current
-hardware — and leave the code cleaner even if a second protocol never ships.
-Running two backends at once means the library appears to CDJs *and* Denon
-players simultaneously.
+Steps 1–2 were pure refactors, fully testable against current hardware, and have
+landed. Steps 3–4 remain pure refactors but are on hold until a second protocol
+is worth validating (see Status) — they leave the code cleaner even if a second
+protocol never ships. The end-state is unchanged: running two backends at once
+means the library appears to CDJs *and* Denon players simultaneously.


### PR DESCRIPTION
## What & why

Documents the modular-import direction that shipped in the import-layer refactor, and keeps the two design docs from drifting.

- Adds docs/design/import-layer.md: the design for generalizing library import behind an ImportBundle plus an Importer registry. Records why the seam lives in library rather than core (import populates the concrete library.Library and carries rekordbox-shaped side-data the neutral core.Importer never modelled), the decisions (rename MasterDB{Cue,Asset} to Imported{Cue,Asset}, extract the apply pipeline, delete the dead core.Importer), and the phased build-green plan.
- Updates docs/design/modular-backends.md: a Status section plus per-step tags so it agrees with the above. Steps 1-2 shipped; the neutral-cache flip (3d) and the serve-side decoupling (steps 3-4) are deferred until a second protocol can be validated on Denon/StageLinq hardware; step 5 (library formats) was pulled forward and is refined by import-layer.md, which lands the adapter in library (not core) and supersedes the thin core.Importer from step 1.

Docs only — this captures decisions from already-merged work; no code changes.

## Hardware testing

- **Tested on:** N/A: documentation only. No code, protocol, or deck-facing change.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass — n/a, docs only (no code changed)
- [x] `gofmt -l .` is clean — n/a, no Go files
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`) — n/a, design docs (Markdown) follow the existing docs/design convention of no SPDX header
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
