### PR TITLE
api + web: configurable stream overlay (now-playing, decks, waveforms, history)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Use it at your own risk, and back up your rekordbox library before importing any
 - **USB export** — write a rekordbox-compatible USB structure (PDB + ANLZ + settings) from the library
 - **Live monitor** TUI showing connected CDJs, playback state, track history, and analysis status
 - **External-source metadata** — when a deck plays a track from its own USB/SD (not from us), the monitor and web PLAYERS view show its real title, artist, key, cover art, waveform, and cue points, read from that player's rekordbox export and ANLZ over NFS, instead of a wrong local ID match
+- **Now-playing overlay** for streaming — a transparent OBS browser source at `/overlay` showing the audible deck's track (artwork, title, artist, BPM/key), driven by the live link state
 
 ## Requirements
 
@@ -136,6 +137,10 @@ drawer (metadata, cues, tags, file path, zoom waveform with beat grid +
 beat-jump), a live PLAYERS view of connected CDJs/mixers, playlist + tag
 management, USB export, and a SETTINGS panel that pushes CDJ display settings
 live.
+
+For streaming, `http://<this-machine>:9443/overlay` is a transparent
+now-playing overlay you can add as an OBS browser source — it shows the audible
+deck's track (artwork, title, artist, BPM/key) and updates live.
 
 ### Import your library
 

--- a/api/api.go
+++ b/api/api.go
@@ -590,6 +590,10 @@ type NowPlaying struct {
 	Key          string  `json:"key,omitempty"`
 	DurationMs   uint32  `json:"duration_ms,omitempty"`
 	BeatInTrack  uint32  `json:"beat_in_track,omitempty"`
+	// ArtworkURL is the cover-art endpoint for the audible track: the library
+	// endpoint for our own tracks, or the external endpoint (the source player's
+	// media over NFS) when a deck plays from its own USB/SD.
+	ArtworkURL string `json:"artwork_url,omitempty"`
 }
 
 func (s *Server) handleNowPlaying(w http.ResponseWriter, r *http.Request) {
@@ -613,6 +617,7 @@ func nowPlayingFrom(players []PlayerInfo) NowPlaying {
 		Key:          p.Key,
 		DurationMs:   p.DurationMs,
 		BeatInTrack:  p.BeatInTrack,
+		ArtworkURL:   p.ArtworkURL,
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -253,6 +253,7 @@ type PlayerInfo struct {
 	Source        string  `json:"source,omitempty"`       // that source, e.g. "USB · player 2"
 	ArtworkURL    string  `json:"artwork_url,omitempty"`  // cover-art endpoint for the loaded track
 	AnalysisURL   string  `json:"analysis_url,omitempty"` // waveform+cues endpoint (external tracks only)
+	WaveformURL   string  `json:"waveform_url,omitempty"` // colour-detail waveform endpoint (local or external)
 	IsPlaying     bool    `json:"is_playing"`
 	IsMaster      bool    `json:"is_master"`
 	IsSync        bool    `json:"is_sync,omitempty"`
@@ -534,14 +535,17 @@ func (s *Server) getPlayers() []PlayerInfo {
 		// media (over NFS), local tracks via the library by track ID.
 		artURL := ""
 		analysisURL := ""
+		waveURL := ""
 		if ps.Status.TrackID > 0 {
 			if ps.External {
 				artURL = fmt.Sprintf("/api/artwork/ext/%d/%d/%d", ps.Status.TrackDevice, ps.Status.TrackSlot, ps.Status.TrackID)
 				// Waveform + cues come from the source player's ANLZ over NFS;
 				// local tracks use the existing track-ID waveform/cue endpoints.
 				analysisURL = fmt.Sprintf("/api/analysis/ext/%d/%d/%d", ps.Status.TrackDevice, ps.Status.TrackSlot, ps.Status.TrackID)
+				waveURL = analysisURL // ext endpoint returns {waveform, beats, duration_ms}
 			} else {
 				artURL = fmt.Sprintf("/api/artwork/%d", ps.Status.TrackID)
+				waveURL = fmt.Sprintf("/api/analysis/waveform/%d?type=detail", ps.Status.TrackID)
 			}
 		}
 		out = append(out, PlayerInfo{
@@ -552,6 +556,7 @@ func (s *Server) getPlayers() []PlayerInfo {
 			Artist:        ps.Artist,
 			ArtworkURL:    artURL,
 			AnalysisURL:   analysisURL,
+			WaveformURL:   waveURL,
 			BPM:           float64(ps.Status.BPM) / 100.0,
 			PitchPct:      pitchPct,
 			Key:           ps.Key,
@@ -594,6 +599,10 @@ type NowPlaying struct {
 	// endpoint for our own tracks, or the external endpoint (the source player's
 	// media over NFS) when a deck plays from its own USB/SD.
 	ArtworkURL string `json:"artwork_url,omitempty"`
+	// WaveformURL is the colour-detail waveform endpoint: the library waveform
+	// endpoint (returns {entries}) for our own tracks, or the external analysis
+	// endpoint (returns {waveform, beats, duration_ms}) for external ones.
+	WaveformURL string `json:"waveform_url,omitempty"`
 }
 
 func (s *Server) handleNowPlaying(w http.ResponseWriter, r *http.Request) {
@@ -618,6 +627,7 @@ func nowPlayingFrom(players []PlayerInfo) NowPlaying {
 		DurationMs:   p.DurationMs,
 		BeatInTrack:  p.BeatInTrack,
 		ArtworkURL:   p.ArtworkURL,
+		WaveformURL:  p.WaveformURL,
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -290,6 +290,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/status", s.handleStatus)
 	mux.HandleFunc("/api/peers", s.handlePeers)
 	mux.HandleFunc("/api/players", s.handlePlayers)
+	mux.HandleFunc("/api/nowplaying", s.handleNowPlaying)
 	mux.HandleFunc("/api/history", s.handleHistory)
 	mux.HandleFunc("/api/tracks", s.handleTracks)
 	mux.HandleFunc("/api/tracks/rev", s.handleTracksRev)
@@ -572,6 +573,73 @@ func (s *Server) getPlayers() []PlayerInfo {
 		return out[i].DeviceNumber < out[j].DeviceNumber
 	})
 	return out
+}
+
+// NowPlaying is the currently-audible track, for the streaming overlay: the
+// on-air playing deck (preferring the tempo master during a transition), or the
+// playing deck when no mixer reports on-air. Playing is false when nothing is.
+type NowPlaying struct {
+	Playing      bool    `json:"playing"`
+	DeviceNumber uint8   `json:"device_number,omitempty"`
+	TrackID      uint32  `json:"track_id,omitempty"`
+	Title        string  `json:"title"`
+	Artist       string  `json:"artist"`
+	BPM          float64 `json:"bpm,omitempty"`
+	Key          string  `json:"key,omitempty"`
+	DurationMs   uint32  `json:"duration_ms,omitempty"`
+	BeatInTrack  uint32  `json:"beat_in_track,omitempty"`
+}
+
+func (s *Server) handleNowPlaying(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	writeJSON(w, nowPlayingFrom(s.getPlayers()))
+}
+
+// nowPlayingFrom projects the selected player into a NowPlaying.
+func nowPlayingFrom(players []PlayerInfo) NowPlaying {
+	p := selectNowPlaying(players)
+	if p == nil {
+		return NowPlaying{}
+	}
+	return NowPlaying{
+		Playing:      true,
+		DeviceNumber: p.DeviceNumber,
+		TrackID:      p.TrackID,
+		Title:        p.TrackTitle,
+		Artist:       p.Artist,
+		BPM:          p.BPM,
+		Key:          p.Key,
+		DurationMs:   p.DurationMs,
+		BeatInTrack:  p.BeatInTrack,
+	}
+}
+
+// selectNowPlaying picks the audible deck from the live states: among decks that
+// are playing with a loaded track, on-air beats off-air, then the tempo master
+// beats the rest, then the lowest device number breaks ties. Returns nil when no
+// deck is playing.
+func selectNowPlaying(players []PlayerInfo) *PlayerInfo {
+	var best *PlayerInfo
+	for i := range players {
+		p := &players[i]
+		if !p.IsPlaying || p.TrackTitle == "" {
+			continue
+		}
+		if best == nil || betterNowPlaying(p, best) {
+			best = p
+		}
+	}
+	return best
+}
+
+func betterNowPlaying(a, b *PlayerInfo) bool {
+	if a.OnAir != b.OnAir {
+		return a.OnAir
+	}
+	if a.IsMaster != b.IsMaster {
+		return a.IsMaster
+	}
+	return a.DeviceNumber < b.DeviceNumber
 }
 
 // TrackInfo is the API representation of a library track. Used by

--- a/api/api.go
+++ b/api/api.go
@@ -56,6 +56,7 @@ type Server struct {
 	Listen       string              // full listen address (e.g. "0.0.0.0:9443"). Takes precedence over Port.
 	Web          bool                // if true, serve the HTML UI at /
 	CacheDir     string              // disk cache root for rendered waveform PNGs etc.
+	Overlay      *OverlayStore       // now-playing streaming-overlay config (optional)
 
 	// ExtArtwork, if set, returns cover-art JPEG bytes for a track a deck plays
 	// from another player's media (downloaded over NFS by package mediadb).
@@ -291,6 +292,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/peers", s.handlePeers)
 	mux.HandleFunc("/api/players", s.handlePlayers)
 	mux.HandleFunc("/api/nowplaying", s.handleNowPlaying)
+	mux.HandleFunc("/api/overlay/config", s.handleOverlayConfig)
 	mux.HandleFunc("/api/history", s.handleHistory)
 	mux.HandleFunc("/api/tracks", s.handleTracks)
 	mux.HandleFunc("/api/tracks/rev", s.handleTracksRev)

--- a/api/nowplaying_test.go
+++ b/api/nowplaying_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package api
+
+import "testing"
+
+func TestSelectNowPlaying(t *testing.T) {
+	p := func(dev uint8, title string, playing, onair, master bool) PlayerInfo {
+		return PlayerInfo{DeviceNumber: dev, TrackTitle: title, IsPlaying: playing, OnAir: onair, IsMaster: master}
+	}
+	cases := []struct {
+		name    string
+		players []PlayerInfo
+		wantDev uint8 // 0 = expect nil
+	}{
+		{"none", nil, 0},
+		{"loaded but not playing", []PlayerInfo{p(1, "A", false, true, true)}, 0},
+		{"playing with no track", []PlayerInfo{p(1, "", true, true, true)}, 0},
+		{"single on-air playing", []PlayerInfo{p(2, "A", true, true, false)}, 2},
+		{"on-air beats off-air", []PlayerInfo{p(1, "A", true, false, true), p(2, "B", true, true, false)}, 2},
+		{"master beats non-master, both on-air", []PlayerInfo{p(3, "A", true, true, false), p(1, "B", true, true, true)}, 1},
+		{"no mixer: master then lowest dev", []PlayerInfo{p(3, "A", true, false, false), p(2, "B", true, false, true)}, 2},
+		{"no mixer, no master: lowest dev", []PlayerInfo{p(3, "A", true, false, false), p(1, "B", true, false, false)}, 1},
+	}
+	for _, c := range cases {
+		got := selectNowPlaying(c.players)
+		if c.wantDev == 0 {
+			if got != nil {
+				t.Errorf("%s: got dev %d, want nil", c.name, got.DeviceNumber)
+			}
+			continue
+		}
+		if got == nil || got.DeviceNumber != c.wantDev {
+			t.Errorf("%s: got %+v, want dev %d", c.name, got, c.wantDev)
+		}
+	}
+}

--- a/api/overlay.go
+++ b/api/overlay.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// OverlayConfig is the now-playing overlay's appearance, edited from the web UI
+// settings tab and read by the /overlay page (which runs in a separate browser,
+// e.g. OBS — hence a server-side store rather than browser-local prefs).
+type OverlayConfig struct {
+	Position string `json:"position"`  // bottom-left | bottom-right | top-left | top-right | bottom-center | top-center
+	Style    string `json:"style"`     // vinyl | cover
+	Accent   string `json:"accent"`    // #rrggbb
+	ShowMeta bool   `json:"show_meta"` // show the BPM / key line
+	Label    string `json:"label"`     // header text (empty = no label)
+}
+
+func defaultOverlayConfig() OverlayConfig {
+	return OverlayConfig{
+		Position: "bottom-left",
+		Style:    "vinyl",
+		Accent:   "#ff7714",
+		ShowMeta: true,
+		Label:    "Now Playing",
+	}
+}
+
+var (
+	overlayPositions = map[string]bool{
+		"bottom-left": true, "bottom-right": true, "top-left": true,
+		"top-right": true, "bottom-center": true, "top-center": true,
+	}
+	overlayStyles = map[string]bool{"vinyl": true, "cover": true}
+	hexColorRe    = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+)
+
+// sanitize clamps a config to valid values, replacing anything invalid with the
+// default so a bad edit or hand-tweaked file can't break the overlay.
+func (c OverlayConfig) sanitize() OverlayConfig {
+	d := defaultOverlayConfig()
+	if !overlayPositions[c.Position] {
+		c.Position = d.Position
+	}
+	if !overlayStyles[c.Style] {
+		c.Style = d.Style
+	}
+	if !hexColorRe.MatchString(c.Accent) {
+		c.Accent = d.Accent
+	}
+	if r := []rune(strings.TrimSpace(c.Label)); len(r) > 40 {
+		c.Label = string(r[:40])
+	} else {
+		c.Label = string(r)
+	}
+	return c
+}
+
+// OverlayStore holds the overlay config in memory and persists it as JSON.
+type OverlayStore struct {
+	mu   sync.RWMutex
+	path string
+	cfg  OverlayConfig
+}
+
+// NewOverlayStore loads the config from path (defaults if absent/invalid).
+func NewOverlayStore(path string) *OverlayStore {
+	s := &OverlayStore{path: path, cfg: defaultOverlayConfig()}
+	if data, err := os.ReadFile(path); err == nil {
+		var c OverlayConfig
+		if json.Unmarshal(data, &c) == nil {
+			s.cfg = c.sanitize()
+		}
+	}
+	return s
+}
+
+func (s *OverlayStore) Get() OverlayConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cfg
+}
+
+func (s *OverlayStore) Set(c OverlayConfig) error {
+	c = c.sanitize()
+	s.mu.Lock()
+	s.cfg = c
+	path := s.path
+	s.mu.Unlock()
+	data, _ := json.MarshalIndent(c, "", "  ")
+	return os.WriteFile(path, data, 0o644)
+}
+
+// handleOverlayConfig serves GET (read) and PUT/POST (update) of the config.
+func (s *Server) handleOverlayConfig(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	switch r.Method {
+	case http.MethodGet:
+		cfg := defaultOverlayConfig()
+		if s.Overlay != nil {
+			cfg = s.Overlay.Get()
+		}
+		writeJSON(w, cfg)
+	case http.MethodPut, http.MethodPost:
+		if s.Overlay == nil {
+			http.Error(w, "overlay config not available", http.StatusServiceUnavailable)
+			return
+		}
+		var c OverlayConfig
+		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+			http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := s.Overlay.Set(c); err != nil {
+			http.Error(w, "save failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, s.Overlay.Get())
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/api/overlay.go
+++ b/api/overlay.go
@@ -15,20 +15,30 @@ import (
 // settings tab and read by the /overlay page (which runs in a separate browser,
 // e.g. OBS — hence a server-side store rather than browser-local prefs).
 type OverlayConfig struct {
-	Position string `json:"position"`  // bottom-left | bottom-right | top-left | top-right | bottom-center | top-center
-	Style    string `json:"style"`     // vinyl | cover
-	Accent   string `json:"accent"`    // #rrggbb
-	ShowMeta bool   `json:"show_meta"` // show the BPM / key line
-	Label    string `json:"label"`     // header text (empty = no label)
+	Position       string `json:"position"`        // bottom-left | bottom-right | top-left | top-right | bottom-center | top-center
+	Style          string `json:"style"`           // vinyl | cover
+	Accent         string `json:"accent"`          // #rrggbb
+	ShowMeta       bool   `json:"show_meta"`       // show the BPM / key line
+	ShowNowplaying bool   `json:"show_nowplaying"` // show the now-playing card (the audible deck)
+	ShowWaveform   bool   `json:"show_waveform"`   // show the now-playing card's scrolling waveform
+	ShowDecks      bool   `json:"show_decks"`      // show the per-deck section (which deck plays what)
+	ShowHistory    bool   `json:"show_history"`    // show the recently-played list
+	HistoryCount   int    `json:"history_count"`   // how many recent tracks to list
+	Label          string `json:"label"`           // header text (empty = no label)
 }
 
 func defaultOverlayConfig() OverlayConfig {
 	return OverlayConfig{
-		Position: "bottom-left",
-		Style:    "vinyl",
-		Accent:   "#ff7714",
-		ShowMeta: true,
-		Label:    "Now Playing",
+		Position:       "bottom-left",
+		Style:          "vinyl",
+		Accent:         "#ff7714",
+		ShowMeta:       true,
+		ShowNowplaying: true,
+		ShowWaveform:   true,
+		ShowDecks:      false,
+		ShowHistory:    false,
+		HistoryCount:   5,
+		Label:          "Now Playing",
 	}
 }
 
@@ -58,6 +68,11 @@ func (c OverlayConfig) sanitize() OverlayConfig {
 		c.Label = string(r[:40])
 	} else {
 		c.Label = string(r)
+	}
+	if c.HistoryCount < 0 {
+		c.HistoryCount = 0
+	} else if c.HistoryCount > 20 {
+		c.HistoryCount = 20
 	}
 	return c
 }

--- a/api/overlay.go
+++ b/api/overlay.go
@@ -24,6 +24,7 @@ type OverlayConfig struct {
 	ShowDecks      bool   `json:"show_decks"`      // show the per-deck section (which deck plays what)
 	ShowHistory    bool   `json:"show_history"`    // show the recently-played list
 	HistoryCount   int    `json:"history_count"`   // how many recent tracks to list
+	Width          int    `json:"width"`           // card width in px
 	Label          string `json:"label"`           // header text (empty = no label)
 }
 
@@ -38,6 +39,7 @@ func defaultOverlayConfig() OverlayConfig {
 		ShowDecks:      false,
 		ShowHistory:    false,
 		HistoryCount:   5,
+		Width:          440,
 		Label:          "Now Playing",
 	}
 }
@@ -73,6 +75,13 @@ func (c OverlayConfig) sanitize() OverlayConfig {
 		c.HistoryCount = 0
 	} else if c.HistoryCount > 20 {
 		c.HistoryCount = 20
+	}
+	if c.Width == 0 {
+		c.Width = d.Width
+	} else if c.Width < 280 {
+		c.Width = 280
+	} else if c.Width > 1000 {
+		c.Width = 1000
 	}
 	return c
 }

--- a/api/web.go
+++ b/api/web.go
@@ -12,6 +12,9 @@ import (
 //go:embed web/index.html
 var webIndexHTML []byte
 
+//go:embed web/overlay.html
+var webOverlayHTML []byte
+
 //go:embed web/favicon.svg
 var webFaviconSVG []byte
 
@@ -34,6 +37,12 @@ func RegisterWebUI(mux *http.ServeMux) {
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Write(webIndexHTML)
+	})
+
+	// Now-playing overlay for streaming (OBS browser source, transparent bg).
+	mux.HandleFunc("/overlay", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(webOverlayHTML)
 	})
 
 	// App icon (vinyl + the null ∅), used as the browser-tab favicon.

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -6956,6 +6956,7 @@ async function saveMenuItems() {
 const SETTINGS_SECTIONS = [
   { key: 'webui',          label: 'WEB UI'         }, // browser-local display prefs (not a CDJ setting)
   { key: 'source',         label: 'LIBRARY SOURCE' }, // rekordbox import + path fix (not a CDJ setting)
+  { key: 'overlay',        label: 'STREAM OVERLAY' }, // now-playing overlay config (not a CDJ setting)
   { key: 'cdj_menu',       label: 'CDJ MENU'       },
   { key: 'my_setting',     label: 'MYSETTING'    },
   { key: 'my_setting_2',   label: 'MYSETTING2'   },
@@ -7005,7 +7006,7 @@ function renderSettings(cfg) {
 
   // CDJ MENU and WEB UI are virtual sections (not part of the settings config);
   // they're always shown, the others appear only when present in cfg.
-  const sectionAvailable = s => s.key === 'cdj_menu' || s.key === 'webui' || s.key === 'source' || !!cfg[s.key];
+  const sectionAvailable = s => s.key === 'cdj_menu' || s.key === 'webui' || s.key === 'source' || s.key === 'overlay' || !!cfg[s.key];
 
   // Render the sidebar with all sections; the body only shows the active one.
   if (nav) {
@@ -7033,11 +7034,17 @@ function renderSettings(cfg) {
   // The top note describes pushing changes to the CDJ — hide it for the
   // browser-local WEB UI section so it doesn't imply those sync to the device.
   const topNote = document.querySelector('#settings .settings-note');
-  if (topNote) topNote.style.display = (section.key === 'webui' || section.key === 'source') ? 'none' : '';
+  if (topNote) topNote.style.display = (section.key === 'webui' || section.key === 'source' || section.key === 'overlay') ? 'none' : '';
 
   // WEB UI: browser-local display preferences (rendered from localStorage, not cfg).
   if (section.key === 'webui') {
     renderWebUISettings(el);
+    return;
+  }
+
+  // STREAM OVERLAY: server-side now-playing overlay config (fetched, not from cfg).
+  if (section.key === 'overlay') {
+    renderOverlaySettings(el);
     return;
   }
 
@@ -7215,6 +7222,59 @@ function renderWebUISettings(el) {
     s.addEventListener('change', () => handleWebUIChange(s)));
   el.querySelectorAll('.cue-default-swatch').forEach(sw =>
     sw.addEventListener('click', () => openDefaultCueColorPicker(sw, parseInt(sw.getAttribute('data-cue-default'), 10))));
+}
+
+// STREAM OVERLAY: edits the server-side now-playing overlay config
+// (/api/overlay/config), which the /overlay page (e.g. in OBS) reads.
+async function renderOverlaySettings(el) {
+  el.innerHTML = '<div class="empty-state">LOADING</div>';
+  let cfg;
+  try {
+    cfg = await (await fetch('/api/overlay/config', { cache: 'no-store' })).json();
+  } catch (e) {
+    el.innerHTML = '<div class="empty-state">OVERLAY CONFIG UNAVAILABLE</div>';
+    return;
+  }
+  const sel = (id, opts, cur) => `<select data-overlay="${id}">${
+    opts.map(([v, t]) => `<option value="${v}" ${v === cur ? 'selected' : ''}>${t}</option>`).join('')
+  }</select>`;
+  const url = location.origin + '/overlay';
+  const labelVal = (cfg.label || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  el.innerHTML = `<div class="settings-block">
+    <div class="head"><span class="inner">STREAM OVERLAY</span></div>
+    <div class="settings-note" style="margin: 6px 8px; border: 0">
+      NOW-PLAYING OVERLAY FOR STREAMING · ADD AN OBS BROWSER SOURCE AT <b>${url}</b> WITH A TRANSPARENT BACKGROUND · CHANGES APPLY LIVE
+    </div>
+    <div class="body">
+      <div class="settings-row"><div class="key">position</div><div class="selector">${sel('position',
+        [['bottom-left', 'Bottom left'], ['bottom-right', 'Bottom right'], ['top-left', 'Top left'],
+         ['top-right', 'Top right'], ['bottom-center', 'Bottom centre'], ['top-center', 'Top centre']], cfg.position)}</div></div>
+      <div class="settings-row"><div class="key">style<div class="row-hint">spinning vinyl, or a square album cover</div></div>
+        <div class="selector">${sel('style', [['vinyl', 'Vinyl (spinning)'], ['cover', 'Cover (square)']], cfg.style)}</div></div>
+      <div class="settings-row"><div class="key">accent colour</div>
+        <div class="selector"><input type="color" data-overlay="accent" value="${cfg.accent}"></div></div>
+      <div class="settings-row"><div class="key">label<div class="row-hint">header text · leave blank to hide</div></div>
+        <div class="selector"><input type="text" class="input" data-overlay="label" value="${labelVal}" maxlength="40" placeholder="Now Playing"></div></div>
+      <div class="settings-row"><div class="key">show BPM / key</div>
+        <div class="selector"><input type="checkbox" data-overlay="show_meta" ${cfg.show_meta !== false ? 'checked' : ''}></div></div>
+      <div class="settings-row"><div class="key"></div><div class="selector">
+        <a href="/overlay" target="_blank" rel="noopener" class="source-btn" style="text-decoration:none">&#8599; Open overlay preview</a></div></div>
+    </div>
+  </div>`;
+  const save = () => {
+    const v = id => el.querySelector(`[data-overlay="${id}"]`);
+    fetch('/api/overlay/config', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        position: v('position').value,
+        style: v('style').value,
+        accent: v('accent').value,
+        label: v('label').value,
+        show_meta: v('show_meta').checked,
+      }),
+    }).then(() => toast('OVERLAY UPDATED', 'success'));
+  };
+  el.querySelectorAll('[data-overlay]').forEach(c => c.addEventListener('change', save));
 }
 function handleWebUIChange(sel) {
   const id = sel.getAttribute('data-webui'), v = sel.value;

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -7266,7 +7266,7 @@ async function renderOverlaySettings(el) {
       <div class="settings-row"><div class="key">recently played</div>
         <div class="selector"><input type="checkbox" data-overlay="show_history" ${cfg.show_history ? 'checked' : ''}></div></div>
       <div class="settings-row"><div class="key">recent count<div class="row-hint">how many tracks in the recently-played list</div></div>
-        <div class="selector"><input type="number" class="input" data-overlay="history_count" value="${cfg.history_count || 5}" min="0" max="20" style="width:64px"></div></div>
+        <div class="selector"><input type="number" class="input" data-overlay="history_count" value="${cfg.history_count || 5}" min="0" max="20" style="width:74px;padding-left:10px;padding-right:6px"></div></div>
       <div class="settings-row"><div class="key"></div><div class="selector">
         <a href="/overlay" target="_blank" rel="noopener" class="source-btn" style="text-decoration:none">&#8599; Open overlay preview</a></div></div>
     </div>

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -7253,6 +7253,8 @@ async function renderOverlaySettings(el) {
         <div class="selector">${sel('style', [['vinyl', 'Vinyl (spinning)'], ['cover', 'Cover (square)']], cfg.style)}</div></div>
       <div class="settings-row"><div class="key">accent colour</div>
         <div class="selector"><input type="color" data-overlay="accent" value="${cfg.accent}"></div></div>
+      <div class="settings-row"><div class="key">width<div class="row-hint">card width in px (280–1000)</div></div>
+        <div class="selector"><input type="number" class="input" data-overlay="width" value="${cfg.width || 440}" min="280" max="1000" step="10" style="width:88px;padding-left:10px;padding-right:6px"></div></div>
       <div class="settings-row"><div class="key">label<div class="row-hint">header text · leave blank to hide</div></div>
         <div class="selector"><input type="text" class="input" data-overlay="label" value="${labelVal}" maxlength="40" placeholder="Now Playing"></div></div>
       <div class="settings-row"><div class="key">show BPM / key</div>
@@ -7286,6 +7288,7 @@ async function renderOverlaySettings(el) {
         show_decks: v('show_decks').checked,
         show_history: v('show_history').checked,
         history_count: parseInt(v('history_count').value, 10) || 0,
+        width: parseInt(v('width').value, 10) || 0,
       }),
     }).then(() => toast('OVERLAY UPDATED', 'success'));
   };

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -7257,6 +7257,16 @@ async function renderOverlaySettings(el) {
         <div class="selector"><input type="text" class="input" data-overlay="label" value="${labelVal}" maxlength="40" placeholder="Now Playing"></div></div>
       <div class="settings-row"><div class="key">show BPM / key</div>
         <div class="selector"><input type="checkbox" data-overlay="show_meta" ${cfg.show_meta !== false ? 'checked' : ''}></div></div>
+      <div class="settings-row"><div class="key">now-playing card<div class="row-hint">the audible deck's track</div></div>
+        <div class="selector"><input type="checkbox" data-overlay="show_nowplaying" ${cfg.show_nowplaying !== false ? 'checked' : ''}></div></div>
+      <div class="settings-row"><div class="key">waveform<div class="row-hint">scrolling waveform under the card</div></div>
+        <div class="selector"><input type="checkbox" data-overlay="show_waveform" ${cfg.show_waveform !== false ? 'checked' : ''}></div></div>
+      <div class="settings-row"><div class="key">decks<div class="row-hint">which deck is playing what, with waveforms</div></div>
+        <div class="selector"><input type="checkbox" data-overlay="show_decks" ${cfg.show_decks ? 'checked' : ''}></div></div>
+      <div class="settings-row"><div class="key">recently played</div>
+        <div class="selector"><input type="checkbox" data-overlay="show_history" ${cfg.show_history ? 'checked' : ''}></div></div>
+      <div class="settings-row"><div class="key">recent count<div class="row-hint">how many tracks in the recently-played list</div></div>
+        <div class="selector"><input type="number" class="input" data-overlay="history_count" value="${cfg.history_count || 5}" min="0" max="20" style="width:64px"></div></div>
       <div class="settings-row"><div class="key"></div><div class="selector">
         <a href="/overlay" target="_blank" rel="noopener" class="source-btn" style="text-decoration:none">&#8599; Open overlay preview</a></div></div>
     </div>
@@ -7271,6 +7281,11 @@ async function renderOverlaySettings(el) {
         accent: v('accent').value,
         label: v('label').value,
         show_meta: v('show_meta').checked,
+        show_nowplaying: v('show_nowplaying').checked,
+        show_waveform: v('show_waveform').checked,
+        show_decks: v('show_decks').checked,
+        show_history: v('show_history').checked,
+        history_count: parseInt(v('history_count').value, 10) || 0,
       }),
     }).then(() => toast('OVERLAY UPDATED', 'success'));
   };

--- a/api/web/overlay.html
+++ b/api/web/overlay.html
@@ -105,6 +105,14 @@
   #sub { font-size: 12px; color: #8a8a8a; margin-top: 8px; letter-spacing: 0.05em; }
   #sub b { color: var(--orange); font-weight: 700; }
 
+  /* --- marquee: scroll text back and forth only when it overflows its box --- */
+  .tx { display: inline-block; white-space: nowrap; will-change: transform; }
+  .tx.scroll { animation: txscroll var(--txdur, 8s) linear infinite alternate; }
+  @keyframes txscroll {
+    0%, 18%   { transform: translateX(0); }
+    82%, 100% { transform: translateX(var(--txshift, 0)); }
+  }
+
   /* --- animated EQ bars --- */
   .eq { display: inline-flex; align-items: flex-end; gap: 2px; height: 11px; }
   .eq i { width: 2px; height: 100%; background: var(--orange); transform-origin: bottom; border-radius: 1px; }
@@ -128,7 +136,8 @@
   .deck-badge { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; color: #0a0a0a;
     background: var(--orange); border-radius: 4px; padding: 2px 6px; flex: 0 0 auto; }
   .deck-badge.idle { background: #3a3a40; color: #b6b6bc; }
-  .deck-track { font-size: 13px; color: #eaeaea; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .deck-track { font-size: 13px; color: #eaeaea; white-space: nowrap; overflow: hidden;
+    flex: 1 1 auto; min-width: 0; }
   .deck-track b { color: #fff; font-weight: 700; }
   .flags { display: inline-flex; gap: 5px; flex: 0 0 auto; }
   .flag { font-size: 9px; letter-spacing: 0.08em; padding: 1px 5px; border-radius: 3px; font-weight: 700; }
@@ -156,8 +165,8 @@
         </div>
         <div class="meta">
           <div class="np-label" id="np-label"><span class="eq"><i></i><i></i><i></i><i></i></span> <span id="np-label-text">Now Playing</span></div>
-          <div id="title"></div>
-          <div id="artist"></div>
+          <div id="title"><span class="tx"></span></div>
+          <div id="artist"><span class="tx"></span></div>
           <div id="sub"></div>
         </div>
       </div>
@@ -172,6 +181,7 @@
     np: $('np'), sectNow: $('nowplaying'), sectDecks: $('decks'), sectHist: $('history'),
     deck: $('deck'), vinyl: $('vinyl'), art: $('art'),
     title: $('title'), artist: $('artist'), sub: $('sub'),
+    titleTx: $('title').querySelector('.tx'), artistTx: $('artist').querySelector('.tx'),
     label: $('np-label'), labelText: $('np-label-text'), npWave: $('np-wave'),
     npWaveCanvas: $('np-wave').querySelector('canvas'),
   };
@@ -184,6 +194,20 @@
   const deckWave = {};  // dev -> { key, entries, durMs, beats }
 
   const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+  // Scroll a `.tx` span back and forth inside its clipping box, but only when it
+  // overflows — so long titles/artists are fully readable instead of clipped.
+  function setupMarquee(tx) {
+    tx.classList.remove('scroll');
+    tx.style.removeProperty('--txshift'); tx.style.removeProperty('--txdur');
+    const over = tx.offsetWidth - tx.parentElement.clientWidth;
+    if (over > 6) {
+      tx.style.setProperty('--txshift', (-over - 4) + 'px');
+      tx.style.setProperty('--txdur', Math.max(5, over / 35).toFixed(1) + 's'); // ~35px/s each way
+      tx.classList.add('scroll');
+    }
+  }
+  function marqueeAll(root) { requestAnimationFrame(() => root.querySelectorAll('.tx').forEach(setupMarquee)); }
 
   // --- waveform data per deck -------------------------------------------------
   function trackKey(p) { return (p.device_number || 0) + '|' + (p.track_id || 0) + '|' + (p.title || p.track_title || ''); }
@@ -279,8 +303,9 @@
 
   // --- now-playing card ------------------------------------------------------
   function applyNow(np) {
-    el.title.textContent = np.title;
-    el.artist.textContent = np.artist || '';
+    el.titleTx.textContent = np.title;
+    el.artistTx.textContent = np.artist || '';
+    marqueeAll(el.sectNow);
     const bits = [];
     if (cfg.show_meta !== false && np.bpm) bits.push(`<b>${np.bpm.toFixed(1)}</b> BPM`);
     if (cfg.show_meta !== false && np.key) bits.push(`<b>${esc(np.key)}</b>`);
@@ -328,12 +353,13 @@
       return `<div class="deck-item">
         <div class="deck-line">
           <span class="deck-badge">${String(p.device_number).padStart(2, '0')}</span>
-          <span class="deck-track"><b>${esc(p.track_title || 'Track ' + p.track_id)}</b>${p.artist ? ' — ' + esc(p.artist) : ''}</span>
+          <span class="deck-track"><span class="tx"><b>${esc(p.track_title || 'Track ' + p.track_id)}</b>${p.artist ? ' — ' + esc(p.artist) : ''}</span></span>
           <span class="flags">${flags}</span>
         </div>
         <div class="wave-wrap"><canvas class="wave" data-dev="${p.device_number}"></canvas></div>
       </div>`;
     }).join('');
+    marqueeAll(el.sectDecks);
     return true;
   }
 
@@ -349,8 +375,9 @@
       histHas = recent.length > 0;
       el.sectHist.innerHTML = recent.length
         ? '<div class="sect-head">Recently Played</div>' + recent.map((h, i) =>
-            `<div class="hist-item"><span class="n">${i + 1}</span><b>${esc(h.title || 'Track ' + h.track_id)}</b>${h.artist ? ' — ' + esc(h.artist) : ''}</div>`).join('')
+            `<div class="hist-item"><span class="n">${i + 1}</span><span class="tx"><b>${esc(h.title || 'Track ' + h.track_id)}</b>${h.artist ? ' — ' + esc(h.artist) : ''}</span></div>`).join('')
         : '';
+      marqueeAll(el.sectHist);
     }
     return histHas;
   }

--- a/api/web/overlay.html
+++ b/api/web/overlay.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!--
+  Vynull now-playing overlay. Add as an OBS "Browser" source pointing at
+  http://<host>:<port>/overlay with a transparent background. Polls
+  /api/nowplaying and shows the audible deck's track as a spinning-vinyl
+  lower-third card.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Vynull — Now Playing</title>
+<style>
+  :root { --orange: #ff7714; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body {
+    background: transparent;
+    overflow: hidden;
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+  }
+
+  #np {
+    position: fixed; left: 40px; bottom: 40px;
+    display: flex; align-items: center; gap: 20px;
+    padding: 16px 28px 16px 16px;
+    background: linear-gradient(180deg, rgba(20, 20, 24, 0.90), rgba(8, 8, 10, 0.93));
+    border: 1px solid rgba(255, 119, 20, 0.28);
+    border-radius: 14px;
+    box-shadow: 0 12px 42px rgba(0, 0, 0, 0.6), 0 0 44px rgba(255, 119, 20, 0.14);
+    max-width: 680px;
+    opacity: 0; transform: translateY(16px);
+    transition: opacity 0.45s ease, transform 0.45s ease;
+  }
+  #np.show { opacity: 1; transform: none; }
+
+  /* --- spinning vinyl --- */
+  .deck { position: relative; width: 108px; height: 108px; flex: 0 0 auto; }
+  .vinyl {
+    width: 100%; height: 100%; border-radius: 50%;
+    background:
+      repeating-radial-gradient(circle at center, #121212 0 2px, #0a0a0a 2px 3px),
+      radial-gradient(circle at center, #1a1a1a 0%, #000 72%);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 6px 22px rgba(0, 0, 0, 0.65),
+                0 0 26px rgba(255, 119, 20, 0.22);
+    animation: spin 1.8s linear infinite;
+  }
+  .label {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    width: 50px; height: 50px; border-radius: 50%; object-fit: cover;
+    box-shadow: 0 0 0 2px #000, 0 0 0 3px rgba(255, 255, 255, 0.14);
+  }
+  .label.hidden { display: none; }
+  .hole {
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    width: 8px; height: 8px; border-radius: 50%;
+    background: #000; box-shadow: 0 0 0 2px #2a2a2a; z-index: 2;
+  }
+  /* fixed light reflection — does not rotate with the record */
+  .sheen {
+    position: absolute; inset: 0; border-radius: 50%; pointer-events: none;
+    background: radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.20), transparent 46%);
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* --- text --- */
+  .meta { min-width: 0; }
+  .np-label {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 10px; letter-spacing: 0.26em; text-transform: uppercase;
+    color: var(--orange); margin-bottom: 6px;
+  }
+  #title {
+    font-size: 23px; font-weight: 700; color: #fff; letter-spacing: 0.01em;
+    text-shadow: 0 0 18px rgba(255, 119, 20, 0.25);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 500px;
+  }
+  #artist {
+    font-size: 15px; color: #d4d4d4; margin-top: 3px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 500px;
+  }
+  #sub { font-size: 12px; color: #8a8a8a; margin-top: 8px; letter-spacing: 0.05em; }
+  #sub b { color: var(--orange); font-weight: 700; }
+
+  /* --- animated EQ bars --- */
+  .eq { display: inline-flex; align-items: flex-end; gap: 2px; height: 11px; }
+  .eq i { width: 2px; height: 100%; background: var(--orange); transform-origin: bottom; border-radius: 1px; }
+  .eq i:nth-child(1) { animation: eq 0.9s ease-in-out infinite; }
+  .eq i:nth-child(2) { animation: eq 0.7s ease-in-out infinite 0.15s; }
+  .eq i:nth-child(3) { animation: eq 1.1s ease-in-out infinite 0.05s; }
+  .eq i:nth-child(4) { animation: eq 0.8s ease-in-out infinite 0.25s; }
+  @keyframes eq { 0%, 100% { transform: scaleY(0.3); } 50% { transform: scaleY(1); } }
+</style>
+</head>
+<body>
+  <div id="np">
+    <div class="deck">
+      <div class="vinyl" id="vinyl">
+        <img id="art" class="label hidden" alt="">
+        <div class="hole"></div>
+      </div>
+      <div class="sheen"></div>
+    </div>
+    <div class="meta">
+      <div class="np-label"><span class="eq"><i></i><i></i><i></i><i></i></span> Now Playing</div>
+      <div id="title"></div>
+      <div id="artist"></div>
+      <div id="sub"></div>
+    </div>
+  </div>
+<script>
+  const el = {
+    np: document.getElementById('np'),
+    vinyl: document.getElementById('vinyl'),
+    art: document.getElementById('art'),
+    title: document.getElementById('title'),
+    artist: document.getElementById('artist'),
+    sub: document.getElementById('sub'),
+  };
+  let curKey = null;
+
+  function apply(np) {
+    el.title.textContent = np.title;
+    el.artist.textContent = np.artist || '';
+    const bits = [];
+    if (np.bpm) bits.push(`<b>${np.bpm.toFixed(1)}</b> BPM`);
+    if (np.key) bits.push(`<b>${np.key}</b>`);
+    el.sub.innerHTML = bits.join(' &nbsp;&middot;&nbsp; ');
+
+    // Spin like a turntable — one rotation per bar (4 beats) at the track's BPM,
+    // so faster tracks visibly spin faster. Default to ~33 RPM when BPM unknown.
+    el.vinyl.style.animationDuration = np.bpm ? (240 / np.bpm).toFixed(3) + 's' : '1.8s';
+
+    if (np.track_id) {
+      el.art.onerror = () => el.art.classList.add('hidden');
+      el.art.classList.remove('hidden');
+      el.art.src = '/api/artwork/' + np.track_id;
+    } else {
+      el.art.classList.add('hidden');
+    }
+    el.np.classList.add('show');
+  }
+
+  function render(np) {
+    if (!np.playing || !np.title) {
+      el.np.classList.remove('show');
+      curKey = null;
+      return;
+    }
+    const key = (np.track_id || 0) + '|' + np.title + '|' + np.artist;
+    if (key === curKey) return; // unchanged — leave the card as-is
+    const wasShowing = el.np.classList.contains('show');
+    curKey = key;
+    if (wasShowing) {
+      el.np.classList.remove('show'); // crossfade: out, swap, in
+      setTimeout(() => apply(np), 400);
+    } else {
+      apply(np);
+    }
+  }
+
+  async function poll() {
+    try {
+      const r = await fetch('/api/nowplaying', { cache: 'no-store' });
+      if (r.ok) render(await r.json());
+    } catch (e) { /* keep polling */ }
+  }
+  poll();
+  setInterval(poll, 1000);
+</script>
+</body>
+</html>

--- a/api/web/overlay.html
+++ b/api/web/overlay.html
@@ -288,6 +288,7 @@
   function applyConfig(c) {
     cfg = c || cfg;
     document.documentElement.style.setProperty('--orange', cfg.accent || '#ff7714');
+    el.np.style.width = (cfg.width && cfg.width >= 280 ? cfg.width : 440) + 'px';
     POSITIONS.forEach(p => el.np.classList.remove('pos-' + p));
     el.np.classList.add('pos-' + (POSITIONS.includes(cfg.position) ? cfg.position : 'bottom-left'));
     el.deck.classList.toggle('cover', cfg.style === 'cover');

--- a/api/web/overlay.html
+++ b/api/web/overlay.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <!--
-  Vynull now-playing overlay. Add as an OBS "Browser" source pointing at
-  http://<host>:<port>/overlay with a transparent background. Appearance
-  (position, vinyl/cover style, accent, label, meta) is configured from the web
-  UI settings tab and served by /api/overlay/config; the track comes from
-  /api/nowplaying (the audible deck).
+  Vynull stream overlay. Add as an OBS "Browser" source pointing at
+  http://<host>:<port>/overlay with a transparent background. Which sections
+  show (now-playing card, per-deck view, recently played) and the appearance
+  are configured from the web UI settings tab and served by /api/overlay/config.
+  Track data comes from /api/nowplaying, /api/players and /api/history.
 -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Vynull — Now Playing</title>
+<title>Vynull — Stream Overlay</title>
 <style>
   :root { --orange: #ff7714; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -22,14 +22,14 @@
 
   #np {
     position: fixed;
-    display: flex; align-items: center; gap: 20px;
-    padding: 16px 28px 16px 16px;
+    display: flex; flex-direction: column; gap: 12px;
+    padding: 16px 20px 16px 16px;
     background: linear-gradient(180deg, rgba(20, 20, 24, 0.90), rgba(8, 8, 10, 0.93));
     border: 1px solid color-mix(in srgb, var(--orange) 30%, transparent);
     border-radius: 14px;
     box-shadow: 0 12px 42px rgba(0, 0, 0, 0.6),
                 0 0 44px color-mix(in srgb, var(--orange) 15%, transparent);
-    max-width: 680px;
+    width: 440px; max-width: 92vw;
     opacity: 0;
     transition: opacity 0.45s ease, transform 0.45s ease;
   }
@@ -47,8 +47,11 @@
   #np.pos-bottom-center, #np.pos-top-center { transform: translate(-50%, 16px); }
   #np.pos-bottom-center.show, #np.pos-top-center.show { transform: translateX(-50%); }
 
+  .section.hidden { display: none; }
+  .np-row { display: flex; align-items: center; gap: 20px; }
+
   /* --- spinning vinyl --- */
-  .deck { position: relative; width: 108px; height: 108px; flex: 0 0 auto; }
+  .deck { position: relative; width: 96px; height: 96px; flex: 0 0 auto; }
   .vinyl {
     width: 100%; height: 100%; border-radius: 50%;
     background:
@@ -60,7 +63,7 @@
   }
   .label {
     position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
-    width: 50px; height: 50px; border-radius: 50%; object-fit: cover;
+    width: 46px; height: 46px; border-radius: 50%; object-fit: cover;
     box-shadow: 0 0 0 2px #000, 0 0 0 3px rgba(255, 255, 255, 0.14);
   }
   .label.hidden { display: none; }
@@ -84,20 +87,20 @@
   }
 
   /* --- text --- */
-  .meta { min-width: 0; }
+  .meta { min-width: 0; flex: 1 1 auto; }
   .np-label {
     display: flex; align-items: center; gap: 8px;
     font-size: 10px; letter-spacing: 0.26em; text-transform: uppercase;
     color: var(--orange); margin-bottom: 6px;
   }
   #title {
-    font-size: 23px; font-weight: 700; color: #fff; letter-spacing: 0.01em;
+    font-size: 22px; font-weight: 700; color: #fff; letter-spacing: 0.01em;
     text-shadow: 0 0 18px color-mix(in srgb, var(--orange) 25%, transparent);
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 500px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   #artist {
     font-size: 15px; color: #d4d4d4; margin-top: 3px;
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 500px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   #sub { font-size: 12px; color: #8a8a8a; margin-top: 8px; letter-spacing: 0.05em; }
   #sub b { color: var(--orange); font-weight: 700; }
@@ -110,42 +113,156 @@
   .eq i:nth-child(3) { animation: eq 1.1s ease-in-out infinite 0.05s; }
   .eq i:nth-child(4) { animation: eq 0.8s ease-in-out infinite 0.25s; }
   @keyframes eq { 0%, 100% { transform: scaleY(0.3); } 50% { transform: scaleY(1); } }
+
+  /* --- scrolling waveform --- */
+  .wave-wrap { position: relative; height: 46px; border-radius: 6px; overflow: hidden;
+    background: rgba(0, 0, 0, 0.34); box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05); }
+  .wave-wrap.hidden { display: none; }
+  canvas.wave { display: block; width: 100%; height: 100%; }
+
+  /* --- decks section --- */
+  #decks { display: flex; flex-direction: column; gap: 10px; }
+  .sect-head { font-size: 9px; letter-spacing: 0.24em; text-transform: uppercase; color: #6f6f74; }
+  .deck-item { display: flex; flex-direction: column; gap: 5px; }
+  .deck-line { display: flex; align-items: center; gap: 8px; min-width: 0; }
+  .deck-badge { font-size: 10px; font-weight: 700; letter-spacing: 0.08em; color: #0a0a0a;
+    background: var(--orange); border-radius: 4px; padding: 2px 6px; flex: 0 0 auto; }
+  .deck-badge.idle { background: #3a3a40; color: #b6b6bc; }
+  .deck-track { font-size: 13px; color: #eaeaea; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .deck-track b { color: #fff; font-weight: 700; }
+  .flags { display: inline-flex; gap: 5px; flex: 0 0 auto; }
+  .flag { font-size: 9px; letter-spacing: 0.08em; padding: 1px 5px; border-radius: 3px; font-weight: 700; }
+  .flag.air { background: #e0301e; color: #fff; }
+  .flag.master { background: color-mix(in srgb, var(--orange) 85%, #000); color: #0a0a0a; }
+  .deck-item .wave-wrap { height: 30px; }
+
+  /* --- history section --- */
+  #history { display: flex; flex-direction: column; gap: 4px; }
+  .hist-item { font-size: 12px; color: #b4b4ba; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .hist-item b { color: #e6e6ea; font-weight: 600; }
+  .hist-item .n { color: #56565c; margin-right: 6px; }
 </style>
 </head>
 <body>
   <div id="np" class="pos-bottom-left">
-    <div class="deck" id="deck">
-      <div class="vinyl" id="vinyl">
-        <img id="art" class="label hidden" alt="">
-        <div class="hole"></div>
+    <div id="nowplaying" class="section">
+      <div class="np-row">
+        <div class="deck" id="deck">
+          <div class="vinyl" id="vinyl">
+            <img id="art" class="label hidden" alt="">
+            <div class="hole"></div>
+          </div>
+          <div class="sheen"></div>
+        </div>
+        <div class="meta">
+          <div class="np-label" id="np-label"><span class="eq"><i></i><i></i><i></i><i></i></span> <span id="np-label-text">Now Playing</span></div>
+          <div id="title"></div>
+          <div id="artist"></div>
+          <div id="sub"></div>
+        </div>
       </div>
-      <div class="sheen"></div>
+      <div class="wave-wrap" id="np-wave"><canvas class="wave" data-dev="0"></canvas></div>
     </div>
-    <div class="meta">
-      <div class="np-label" id="np-label"><span class="eq"><i></i><i></i><i></i><i></i></span> <span id="np-label-text">Now Playing</span></div>
-      <div id="title"></div>
-      <div id="artist"></div>
-      <div id="sub"></div>
-    </div>
+    <div id="decks" class="section hidden"></div>
+    <div id="history" class="section hidden"></div>
   </div>
 <script>
+  const $ = id => document.getElementById(id);
   const el = {
-    np: document.getElementById('np'),
-    deck: document.getElementById('deck'),
-    vinyl: document.getElementById('vinyl'),
-    art: document.getElementById('art'),
-    title: document.getElementById('title'),
-    artist: document.getElementById('artist'),
-    sub: document.getElementById('sub'),
-    label: document.getElementById('np-label'),
-    labelText: document.getElementById('np-label-text'),
+    np: $('np'), sectNow: $('nowplaying'), sectDecks: $('decks'), sectHist: $('history'),
+    deck: $('deck'), vinyl: $('vinyl'), art: $('art'),
+    title: $('title'), artist: $('artist'), sub: $('sub'),
+    label: $('np-label'), labelText: $('np-label-text'), npWave: $('np-wave'),
+    npWaveCanvas: $('np-wave').querySelector('canvas'),
   };
   const POSITIONS = ['bottom-left', 'bottom-right', 'top-left', 'top-right', 'bottom-center', 'top-center'];
-  let curKey = null;
-  let showMeta = true;
-  let artToken = 0;
+  let cfg = { show_nowplaying: true, show_waveform: true, show_meta: true, show_decks: false, show_history: false, history_count: 5, style: 'vinyl' };
+  let curTrackKey = null, artToken = 0;
 
-  function applyConfig(cfg) {
+  // Per-deck state, keyed by device number.
+  const deckPos = {};   // dev -> { posMs, durMs, sampledAt }
+  const deckWave = {};  // dev -> { key, entries, durMs, beats }
+
+  const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+  // --- waveform data per deck -------------------------------------------------
+  function trackKey(p) { return (p.device_number || 0) + '|' + (p.track_id || 0) + '|' + (p.title || p.track_title || ''); }
+
+  function ensureWave(dev, key, url, fallbackDur) {
+    if (deckWave[dev] && deckWave[dev].key === key) return;    // already have / fetching this track
+    deckWave[dev] = { key, entries: null, durMs: fallbackDur || 0, beats: null };
+    if (!url) return;
+    let tries = 0;
+    const go = () => {
+      if (!deckWave[dev] || deckWave[dev].key !== key) return; // track changed under us
+      fetch(url, { cache: 'no-store' }).then(r => r.ok ? r.json() : null).then(d => {
+        if (!deckWave[dev] || deckWave[dev].key !== key) return;
+        if (!d) { if (++tries < 8) setTimeout(go, 1500); return; } // ext waveform 404s until it downloads
+        deckWave[dev] = { key, entries: d.entries || d.waveform || [], durMs: d.duration_ms || fallbackDur || 0, beats: d.beats || null };
+      }).catch(() => {});
+    };
+    go();
+  }
+
+  // Sample a deck's position from its beat/bpm (or exact beat grid) each poll.
+  function sampleDeck(p) {
+    const dev = p.device_number;
+    if (!dev || !p.track_id) { delete deckPos[dev]; return; }
+    ensureWave(dev, trackKey(p), p.waveform_url, p.duration_ms || 0);
+    const w = deckWave[dev];
+    const durMs = (w && w.durMs) || p.duration_ms || 0;
+    let posMs = 0;
+    if (w && w.beats && p.beat_in_track > 0 && p.beat_in_track <= w.beats.length) posMs = w.beats[p.beat_in_track - 1];
+    else if (p.beat_in_track > 0 && p.bpm > 0) posMs = (p.beat_in_track - 1) * 60000 / p.bpm;
+    deckPos[dev] = { posMs, durMs, sampledAt: performance.now() };
+  }
+
+  // --- scrolling waveform render (rAF) ---------------------------------------
+  const WINDOW_SEC = 12, ENTRY_RATE = 150; // PWV5 is 150 entries/sec
+  function drawWave(cv, w, pos, now) {
+    if (cv.width !== cv.clientWidth || cv.height !== cv.clientHeight) {
+      cv.width = cv.clientWidth || 300; cv.height = cv.clientHeight || 40;
+    }
+    const ctx = cv.getContext('2d'), W = cv.width, H = cv.height;
+    ctx.clearRect(0, 0, W, H);
+    if (!w || !w.entries || !w.entries.length || !pos || !pos.durMs) return;
+    const posMs = pos.posMs + (now - pos.sampledAt); // 1x interpolation between polls
+    const cur = (posMs / 1000) * ENTRY_RATE;
+    const epp = (WINDOW_SEC * ENTRY_RATE) / W; // entries per pixel
+    const n = w.entries.length;
+    for (let x = 0; x < W; x++) {
+      const f0 = cur + (x - W / 2) * epp;
+      let i0 = Math.floor(f0), i1 = Math.max(i0 + 1, Math.floor(f0 + epp));
+      let mh = 0, r = 0, g = 0, b = 0, c = 0;
+      for (let i = i0; i < i1; i++) {
+        if (i < 0 || i >= n) continue;
+        const e = w.entries[i]; const h = e.h || 0;
+        if (h > mh) mh = h; r += e.r || 0; g += e.g || 0; b += e.b || 0; c++;
+      }
+      if (!c) continue;
+      const bh = Math.max(1, mh / 31 * H);
+      ctx.globalAlpha = x < W / 2 ? 1 : 0.45; // dim the not-yet-played side
+      ctx.fillStyle = `rgb(${Math.round(r / c * 36)},${Math.round(g / c * 36)},${Math.round(b / c * 36)})`;
+      ctx.fillRect(x, H - bh, 1, bh);
+    }
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = '#fff';
+    ctx.fillRect((W >> 1), 0, 2, H); // fixed centre playhead
+  }
+
+  function tick() {
+    requestAnimationFrame(tick);
+    const now = performance.now();
+    document.querySelectorAll('canvas.wave').forEach(cv => {
+      const dev = +cv.dataset.dev;
+      drawWave(cv, deckWave[dev], deckPos[dev], now);
+    });
+  }
+  requestAnimationFrame(tick);
+
+  // --- config ----------------------------------------------------------------
+  function applyConfig(c) {
+    cfg = c || cfg;
     document.documentElement.style.setProperty('--orange', cfg.accent || '#ff7714');
     POSITIONS.forEach(p => el.np.classList.remove('pos-' + p));
     el.np.classList.add('pos-' + (POSITIONS.includes(cfg.position) ? cfg.position : 'bottom-left'));
@@ -153,68 +270,110 @@
     const label = (cfg.label || '').trim();
     el.labelText.textContent = label;
     el.label.style.display = label ? '' : 'none';
-    showMeta = cfg.show_meta !== false;
-    el.sub.style.display = showMeta ? '' : 'none';
+    el.sub.style.display = cfg.show_meta !== false ? '' : 'none';
+    el.sectNow.classList.toggle('hidden', cfg.show_nowplaying === false);
+    el.npWave.classList.toggle('hidden', cfg.show_waveform === false);
+    el.sectDecks.classList.toggle('hidden', !cfg.show_decks);
+    el.sectHist.classList.toggle('hidden', !cfg.show_history);
   }
 
-  function apply(np) {
+  // --- now-playing card ------------------------------------------------------
+  function applyNow(np) {
     el.title.textContent = np.title;
     el.artist.textContent = np.artist || '';
     const bits = [];
-    if (showMeta && np.bpm) bits.push(`<b>${np.bpm.toFixed(1)}</b> BPM`);
-    if (showMeta && np.key) bits.push(`<b>${np.key}</b>`);
+    if (cfg.show_meta !== false && np.bpm) bits.push(`<b>${np.bpm.toFixed(1)}</b> BPM`);
+    if (cfg.show_meta !== false && np.key) bits.push(`<b>${esc(np.key)}</b>`);
     el.sub.innerHTML = bits.join(' &nbsp;&middot;&nbsp; ');
-
-    // Spin like a turntable — one rotation per bar (4 beats) at the track's BPM.
     el.vinyl.style.animationDuration = np.bpm ? (240 / np.bpm).toFixed(3) + 's' : '1.8s';
+    el.npWaveCanvas.dataset.dev = np.device_number || 0;
 
-    // Cover art from the server-provided URL (the library endpoint for our own
-    // tracks, the external endpoint for a deck playing off its own USB). The
-    // external art 404s until it downloads over NFS, so retry a few times;
-    // artToken aborts a stale retry loop once the track changes.
     artToken++;
     const myToken = artToken;
     if (np.artwork_url) {
       let tries = 0;
       const loadArt = () => {
-        if (myToken !== artToken) return; // track changed
+        if (myToken !== artToken) return;
         el.art.onload = () => { if (myToken === artToken) el.art.classList.remove('hidden'); };
-        el.art.onerror = () => {
-          if (myToken !== artToken) return;
-          el.art.classList.add('hidden');
-          if (++tries < 8) setTimeout(loadArt, 1500);
-        };
+        el.art.onerror = () => { if (myToken !== artToken) return; el.art.classList.add('hidden'); if (++tries < 8) setTimeout(loadArt, 1500); };
         el.art.src = np.artwork_url + (tries ? (np.artwork_url.indexOf('?') >= 0 ? '&' : '?') + 'r=' + tries : '');
       };
       loadArt();
-    } else {
-      el.art.classList.add('hidden');
-    }
-    el.np.classList.add('show');
+    } else { el.art.classList.add('hidden'); }
   }
 
-  function render(np) {
-    if (!np.playing || !np.title) {
-      el.np.classList.remove('show');
-      curKey = null;
-      return;
+  function renderNow(np) {
+    if (np && np.playing && np.title) {
+      sampleDeck(np);
+      const key = trackKey(np);
+      if (key !== curTrackKey) { curTrackKey = key; applyNow(np); }
+      return true;
     }
-    const key = (np.track_id || 0) + '|' + np.title + '|' + np.artist;
-    if (key === curKey) return; // unchanged
-    const wasShowing = el.np.classList.contains('show');
-    curKey = key;
-    if (wasShowing) {
-      el.np.classList.remove('show'); // crossfade: out, swap, in
-      setTimeout(() => apply(np), 400);
-    } else {
-      apply(np);
-    }
+    curTrackKey = null;
+    return false;
   }
 
-  async function pollNowPlaying() {
+  // --- decks section ---------------------------------------------------------
+  let decksKey = '';
+  function renderDecks(players) {
+    const playing = (players || []).filter(p => p.is_playing && p.track_id);
+    playing.forEach(sampleDeck);
+    if (cfg.show_decks === false || cfg.show_decks === undefined) return playing.length > 0;
+    const key = playing.map(p => trackKey(p) + (p.on_air ? 'A' : '') + (p.is_master ? 'M' : '')).join('~');
+    if (key === decksKey) return playing.length > 0; // unchanged; canvases keep drawing
+    decksKey = key;
+    if (!playing.length) { el.sectDecks.innerHTML = ''; return false; }
+    el.sectDecks.innerHTML = '<div class="sect-head">Decks</div>' + playing.map(p => {
+      const flags = (p.on_air ? '<span class="flag air">ON AIR</span>' : '') + (p.is_master ? '<span class="flag master">MASTER</span>' : '');
+      return `<div class="deck-item">
+        <div class="deck-line">
+          <span class="deck-badge">${String(p.device_number).padStart(2, '0')}</span>
+          <span class="deck-track"><b>${esc(p.track_title || 'Track ' + p.track_id)}</b>${p.artist ? ' — ' + esc(p.artist) : ''}</span>
+          <span class="flags">${flags}</span>
+        </div>
+        <div class="wave-wrap"><canvas class="wave" data-dev="${p.device_number}"></canvas></div>
+      </div>`;
+    }).join('');
+    return true;
+  }
+
+  // --- history section -------------------------------------------------------
+  let histKey = '', histHas = false;
+  function renderHistory(items) {
+    if (!cfg.show_history) { histHas = false; return false; }
+    const n = Math.max(0, Math.min(20, cfg.history_count || 5));
+    const recent = (items || []).slice().reverse().slice(0, n); // newest first
+    const key = recent.map(h => h.track_id + '|' + h.title).join('~') + '|' + n;
+    if (key !== histKey) {
+      histKey = key;
+      histHas = recent.length > 0;
+      el.sectHist.innerHTML = recent.length
+        ? '<div class="sect-head">Recently Played</div>' + recent.map((h, i) =>
+            `<div class="hist-item"><span class="n">${i + 1}</span><b>${esc(h.title || 'Track ' + h.track_id)}</b>${h.artist ? ' — ' + esc(h.artist) : ''}</div>`).join('')
+        : '';
+    }
+    return histHas;
+  }
+
+  // --- polling ---------------------------------------------------------------
+  async function poll() {
     try {
-      const r = await fetch('/api/nowplaying', { cache: 'no-store' });
-      if (r.ok) render(await r.json());
+      const [np, players, history] = await Promise.all([
+        fetch('/api/nowplaying', { cache: 'no-store' }).then(r => r.ok ? r.json() : null).catch(() => null),
+        (cfg.show_decks ? fetch('/api/players', { cache: 'no-store' }).then(r => r.ok ? r.json() : []).catch(() => []) : Promise.resolve([])),
+        (cfg.show_history ? fetch('/api/history', { cache: 'no-store' }).then(r => r.ok ? r.json() : []).catch(() => []) : Promise.resolve([])),
+      ]);
+      const nowShown = renderNow(np);
+      const decksShown = renderDecks(players);
+      const histShown = renderHistory(history);
+      // Drop stale per-deck state for decks that are gone.
+      const live = new Set((players || []).map(p => p.device_number));
+      if (np && np.device_number) live.add(np.device_number);
+      for (const d of Object.keys(deckPos)) if (!live.has(+d)) { delete deckPos[d]; delete deckWave[d]; }
+      // Show the panel if any enabled section has content.
+      const anything = (cfg.show_nowplaying !== false && nowShown) ||
+        (cfg.show_decks && decksShown) || (cfg.show_history && histShown);
+      el.np.classList.toggle('show', !!anything);
     } catch (e) { /* keep polling */ }
   }
   async function pollConfig() {
@@ -225,8 +384,8 @@
   }
 
   pollConfig();
-  pollNowPlaying();
-  setInterval(pollNowPlaying, 1000);
+  poll();
+  setInterval(poll, 1000);
   setInterval(pollConfig, 5000); // pick up settings-tab edits live
 </script>
 </body>

--- a/api/web/overlay.html
+++ b/api/web/overlay.html
@@ -143,6 +143,7 @@
   const POSITIONS = ['bottom-left', 'bottom-right', 'top-left', 'top-right', 'bottom-center', 'top-center'];
   let curKey = null;
   let showMeta = true;
+  let artToken = 0;
 
   function applyConfig(cfg) {
     document.documentElement.style.setProperty('--orange', cfg.accent || '#ff7714');
@@ -167,10 +168,25 @@
     // Spin like a turntable — one rotation per bar (4 beats) at the track's BPM.
     el.vinyl.style.animationDuration = np.bpm ? (240 / np.bpm).toFixed(3) + 's' : '1.8s';
 
-    if (np.track_id) {
-      el.art.onerror = () => el.art.classList.add('hidden');
-      el.art.classList.remove('hidden');
-      el.art.src = '/api/artwork/' + np.track_id;
+    // Cover art from the server-provided URL (the library endpoint for our own
+    // tracks, the external endpoint for a deck playing off its own USB). The
+    // external art 404s until it downloads over NFS, so retry a few times;
+    // artToken aborts a stale retry loop once the track changes.
+    artToken++;
+    const myToken = artToken;
+    if (np.artwork_url) {
+      let tries = 0;
+      const loadArt = () => {
+        if (myToken !== artToken) return; // track changed
+        el.art.onload = () => { if (myToken === artToken) el.art.classList.remove('hidden'); };
+        el.art.onerror = () => {
+          if (myToken !== artToken) return;
+          el.art.classList.add('hidden');
+          if (++tries < 8) setTimeout(loadArt, 1500);
+        };
+        el.art.src = np.artwork_url + (tries ? (np.artwork_url.indexOf('?') >= 0 ? '&' : '?') + 'r=' + tries : '');
+      };
+      loadArt();
     } else {
       el.art.classList.add('hidden');
     }

--- a/api/web/overlay.html
+++ b/api/web/overlay.html
@@ -2,9 +2,10 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <!--
   Vynull now-playing overlay. Add as an OBS "Browser" source pointing at
-  http://<host>:<port>/overlay with a transparent background. Polls
-  /api/nowplaying and shows the audible deck's track as a spinning-vinyl
-  lower-third card.
+  http://<host>:<port>/overlay with a transparent background. Appearance
+  (position, vinyl/cover style, accent, label, meta) is configured from the web
+  UI settings tab and served by /api/overlay/config; the track comes from
+  /api/nowplaying (the audible deck).
 -->
 <html lang="en">
 <head>
@@ -20,18 +21,31 @@
   }
 
   #np {
-    position: fixed; left: 40px; bottom: 40px;
+    position: fixed;
     display: flex; align-items: center; gap: 20px;
     padding: 16px 28px 16px 16px;
     background: linear-gradient(180deg, rgba(20, 20, 24, 0.90), rgba(8, 8, 10, 0.93));
-    border: 1px solid rgba(255, 119, 20, 0.28);
+    border: 1px solid color-mix(in srgb, var(--orange) 30%, transparent);
     border-radius: 14px;
-    box-shadow: 0 12px 42px rgba(0, 0, 0, 0.6), 0 0 44px rgba(255, 119, 20, 0.14);
+    box-shadow: 0 12px 42px rgba(0, 0, 0, 0.6),
+                0 0 44px color-mix(in srgb, var(--orange) 15%, transparent);
     max-width: 680px;
-    opacity: 0; transform: translateY(16px);
+    opacity: 0;
     transition: opacity 0.45s ease, transform 0.45s ease;
   }
-  #np.show { opacity: 1; transform: none; }
+  #np.show { opacity: 1; }
+
+  /* position — corners translate the card up while fading; centres also -50% X */
+  #np.pos-bottom-left   { left: 40px; bottom: 40px; }
+  #np.pos-bottom-right  { right: 40px; bottom: 40px; }
+  #np.pos-top-left      { left: 40px; top: 40px; }
+  #np.pos-top-right     { right: 40px; top: 40px; }
+  #np.pos-bottom-center { left: 50%; bottom: 40px; }
+  #np.pos-top-center    { left: 50%; top: 40px; }
+  #np:not(.pos-bottom-center):not(.pos-top-center) { transform: translateY(16px); }
+  #np:not(.pos-bottom-center):not(.pos-top-center).show { transform: none; }
+  #np.pos-bottom-center, #np.pos-top-center { transform: translate(-50%, 16px); }
+  #np.pos-bottom-center.show, #np.pos-top-center.show { transform: translateX(-50%); }
 
   /* --- spinning vinyl --- */
   .deck { position: relative; width: 108px; height: 108px; flex: 0 0 auto; }
@@ -41,7 +55,7 @@
       repeating-radial-gradient(circle at center, #121212 0 2px, #0a0a0a 2px 3px),
       radial-gradient(circle at center, #1a1a1a 0%, #000 72%);
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 6px 22px rgba(0, 0, 0, 0.65),
-                0 0 26px rgba(255, 119, 20, 0.22);
+                0 0 26px color-mix(in srgb, var(--orange) 22%, transparent);
     animation: spin 1.8s linear infinite;
   }
   .label {
@@ -55,12 +69,19 @@
     width: 8px; height: 8px; border-radius: 50%;
     background: #000; box-shadow: 0 0 0 2px #2a2a2a; z-index: 2;
   }
-  /* fixed light reflection — does not rotate with the record */
   .sheen {
     position: absolute; inset: 0; border-radius: 50%; pointer-events: none;
     background: radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.20), transparent 46%);
   }
   @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* --- cover style: square art, no spin --- */
+  .deck.cover .vinyl { animation: none; background: none; box-shadow: none; }
+  .deck.cover .hole, .deck.cover .sheen { display: none; }
+  .deck.cover .label {
+    position: static; transform: none; width: 100%; height: 100%; border-radius: 10px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.55), 0 0 24px color-mix(in srgb, var(--orange) 18%, transparent);
+  }
 
   /* --- text --- */
   .meta { min-width: 0; }
@@ -71,7 +92,7 @@
   }
   #title {
     font-size: 23px; font-weight: 700; color: #fff; letter-spacing: 0.01em;
-    text-shadow: 0 0 18px rgba(255, 119, 20, 0.25);
+    text-shadow: 0 0 18px color-mix(in srgb, var(--orange) 25%, transparent);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 500px;
   }
   #artist {
@@ -92,8 +113,8 @@
 </style>
 </head>
 <body>
-  <div id="np">
-    <div class="deck">
+  <div id="np" class="pos-bottom-left">
+    <div class="deck" id="deck">
       <div class="vinyl" id="vinyl">
         <img id="art" class="label hidden" alt="">
         <div class="hole"></div>
@@ -101,7 +122,7 @@
       <div class="sheen"></div>
     </div>
     <div class="meta">
-      <div class="np-label"><span class="eq"><i></i><i></i><i></i><i></i></span> Now Playing</div>
+      <div class="np-label" id="np-label"><span class="eq"><i></i><i></i><i></i><i></i></span> <span id="np-label-text">Now Playing</span></div>
       <div id="title"></div>
       <div id="artist"></div>
       <div id="sub"></div>
@@ -110,24 +131,40 @@
 <script>
   const el = {
     np: document.getElementById('np'),
+    deck: document.getElementById('deck'),
     vinyl: document.getElementById('vinyl'),
     art: document.getElementById('art'),
     title: document.getElementById('title'),
     artist: document.getElementById('artist'),
     sub: document.getElementById('sub'),
+    label: document.getElementById('np-label'),
+    labelText: document.getElementById('np-label-text'),
   };
+  const POSITIONS = ['bottom-left', 'bottom-right', 'top-left', 'top-right', 'bottom-center', 'top-center'];
   let curKey = null;
+  let showMeta = true;
+
+  function applyConfig(cfg) {
+    document.documentElement.style.setProperty('--orange', cfg.accent || '#ff7714');
+    POSITIONS.forEach(p => el.np.classList.remove('pos-' + p));
+    el.np.classList.add('pos-' + (POSITIONS.includes(cfg.position) ? cfg.position : 'bottom-left'));
+    el.deck.classList.toggle('cover', cfg.style === 'cover');
+    const label = (cfg.label || '').trim();
+    el.labelText.textContent = label;
+    el.label.style.display = label ? '' : 'none';
+    showMeta = cfg.show_meta !== false;
+    el.sub.style.display = showMeta ? '' : 'none';
+  }
 
   function apply(np) {
     el.title.textContent = np.title;
     el.artist.textContent = np.artist || '';
     const bits = [];
-    if (np.bpm) bits.push(`<b>${np.bpm.toFixed(1)}</b> BPM`);
-    if (np.key) bits.push(`<b>${np.key}</b>`);
+    if (showMeta && np.bpm) bits.push(`<b>${np.bpm.toFixed(1)}</b> BPM`);
+    if (showMeta && np.key) bits.push(`<b>${np.key}</b>`);
     el.sub.innerHTML = bits.join(' &nbsp;&middot;&nbsp; ');
 
-    // Spin like a turntable — one rotation per bar (4 beats) at the track's BPM,
-    // so faster tracks visibly spin faster. Default to ~33 RPM when BPM unknown.
+    // Spin like a turntable — one rotation per bar (4 beats) at the track's BPM.
     el.vinyl.style.animationDuration = np.bpm ? (240 / np.bpm).toFixed(3) + 's' : '1.8s';
 
     if (np.track_id) {
@@ -147,7 +184,7 @@
       return;
     }
     const key = (np.track_id || 0) + '|' + np.title + '|' + np.artist;
-    if (key === curKey) return; // unchanged — leave the card as-is
+    if (key === curKey) return; // unchanged
     const wasShowing = el.np.classList.contains('show');
     curKey = key;
     if (wasShowing) {
@@ -158,14 +195,23 @@
     }
   }
 
-  async function poll() {
+  async function pollNowPlaying() {
     try {
       const r = await fetch('/api/nowplaying', { cache: 'no-store' });
       if (r.ok) render(await r.json());
     } catch (e) { /* keep polling */ }
   }
-  poll();
-  setInterval(poll, 1000);
+  async function pollConfig() {
+    try {
+      const r = await fetch('/api/overlay/config', { cache: 'no-store' });
+      if (r.ok) applyConfig(await r.json());
+    } catch (e) { /* keep defaults */ }
+  }
+
+  pollConfig();
+  pollNowPlaying();
+  setInterval(pollNowPlaying, 1000);
+  setInterval(pollConfig, 5000); // pick up settings-tab edits live
 </script>
 </body>
 </html>

--- a/main.go
+++ b/main.go
@@ -592,6 +592,7 @@ func main() {
 		CacheDir:     cfg.DataDir, // for rendered waveform PNGs etc.
 		ExtArtwork:   extMeta.Artwork,
 		ExtAnalysis:  extMeta.Analysis,
+		Overlay:      api.NewOverlayStore(filepath.Join(cfg.DataDir, "overlay.json")),
 	}
 	if cfg.Web {
 		log.Printf("web UI enabled: http://%s/", displayAddr(cfg.Listen))


### PR DESCRIPTION
## What & why

Adds a transparent stream overlay served at `/overlay`, for use as an OBS browser source, driven entirely by the link state Vynull already tracks. Point OBS at `http://<this-machine>:9443/overlay` and it shows what is playing, live, with a transparent background and no external assets or extra process. It started as a simple now-playing card and grew into a small, configurable overlay with several sections a DJ can turn on or off from the settings tab.

Everything it needs already exists server-side (player status, the loaded track, artwork, and the colour-detail waveform, including for tracks a deck plays from its own USB). This is mostly a richer client plus a server-side config store, and it touches nothing on the deck-facing protocol, the load path, or analysis.

## Sections (each toggleable in the settings tab)

- Now-playing card: the audible deck's track as a turntable-style card, a spinning vinyl (or static cover) with the real cover art, title, artist, and an optional BPM/key line.
- Scrolling waveform: a CDJ-style window that scrolls past a fixed centre playhead, the played side full and the upcoming side dimmed.
- Decks: every playing deck with its track, ON AIR / MASTER flags, and its own scrolling waveform, so viewers can see which deck is playing what.
- Recently played: the last N tracks (count configurable) from the play history.

## Selecting the audible deck

`/api/nowplaying` picks the one deck for the now-playing card. `selectNowPlaying` considers only decks that are playing with a loaded track, then ranks them: on-air beats off-air, then the tempo master, then the lowest device number. It is a pure function over the `PlayerInfo` snapshot with unit tests. The endpoint returns the winner's title, artist, BPM, key, duration, beat-in-track, and the cover-art and waveform URLs.

## Cover art and waveforms, local or external

The overlay never builds media URLs itself. `getPlayers` (and `nowPlayingFrom`) hand it an `artwork_url` and `waveform_url` per track: the library endpoints for our own tracks, or the external endpoints (the source player's media over NFS, already on main) when a deck plays from its own USB or SD. So the same overlay code draws art and waveforms for both, and an external asset that 404s until it downloads over NFS is retried a few times.

The waveform is rendered in a `requestAnimationFrame` loop: the position comes from the ANLZ beat grid when available (exact under pitch) or `beat_in_track` and BPM otherwise, interpolated between the 1Hz polls so the playhead moves smoothly. Per-deck waveform data is keyed by device number and shared between the card and the decks list, so a deck that appears in both is fetched once.

## Configuration

The overlay runs in a separate browser (OBS), so its configuration lives server-side rather than in the main UI's local storage. `OverlayStore` persists to `DataDir/overlay.json` and is exposed at `/api/overlay/config` (GET/PUT). `OverlayConfig` covers position (six anchors), style (spinning vinyl or static cover), accent colour, card width, an optional header label, whether to show the BPM/key line, and toggles for the now-playing card, waveform, decks, and recently-played sections plus the recent-count. Values are sanitised on read and write. A STREAM OVERLAY section in the settings tab edits it, and `/overlay` re-polls the config every 5s so changes apply live without reloading the OBS source.

## Details

- Long titles and artists scroll gently back and forth only when they overflow their box, so nothing is clipped; text that fits stays put. Applied to the card, the per-deck line, and the history list.
- The panel fades in only when an enabled section has something to show, and fades out when nothing is playing.
- Cover art reuses the existing artwork endpoints, so there are no new assets.

## Verification

`selectNowPlaying` is covered by unit tests (no candidates, a single candidate, and the multi-deck on-air / master / lowest-number tie-breaks). `go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt -l .` are clean. The overlay page and the settings section were exercised in the browser against live decks.

## Hardware testing

- **Tested on:** CDJ-2000NXS2. This is a read-only web/overlay layer over existing status data and changes nothing on the load, serve, or analysis paths, so it cannot affect deck behaviour. Checked live in the browser with the deck playing: the now-playing card, scrolling waveforms, decks section, recently-played list, and the settings toggles (including for a track played from the deck's own USB, which reuses the external artwork/waveform endpoints).

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
