### PR TITLE
mediadb: resolve external metadata per media slot (USB / SD, skip CD)

### DIFF
--- a/docs/design/external-metadata.md
+++ b/docs/design/external-metadata.md
@@ -91,8 +91,11 @@ framing is familiar — but the client handshake and menu-render flow are new.
   Served at `/api/analysis/ext/{player}/{slot}/{trackID}` (via `Server.ExtAnalysis`);
   the PLAYERS card renders the real waveform and cue markers instead of
   "WAVEFORM UNAVAILABLE" (`PlayerInfo.AnalysisURL`). Needs a deck to confirm the
-  ANLZ path resolves on real media. Beat grid overlay in the detail drawer and
-  the overlay's reuse are possible follow-ups.
+  ANLZ path resolves on real media. The now-playing overlay reuses this (waveform
+  per deck) since the overlay merged. A beat-grid / zoom view for external tracks
+  would need a dedicated inspector rather than the library-track detail drawer
+  (which is built around a library track object and its deck-control features),
+  so it is deferred as its own feature, not a loose end.
 
 ### Known limitations (need a deck)
 

--- a/docs/design/external-metadata.md
+++ b/docs/design/external-metadata.md
@@ -96,10 +96,13 @@ framing is familiar — but the client handshake and menu-render flow are new.
 
 ### Known limitations (need a deck)
 
-- The export-name -> slot mapping is best-effort: `FetchExportPDB` tries the
-  advertised MOUNT EXPORT list, then `/C/`, `/B/`, `/`. If a deck has both a USB
-  and an SD with databases, both slot keys currently resolve to the first export
-  found. Fixable once we see a real deck's export list per slot.
+- The export-name -> slot mapping is slot-aware but best-effort. `mediadb`
+  passes `FetchExportPDB` a preferred export per slot (USB(3)->/C/ confirmed on
+  hardware, SD(2)->/B/ and CD(1)->/A/ guessed), tried before the advertised
+  MOUNT EXPORT list and the common roots. So a player with both a USB and an SD
+  no longer collapses both slots onto the first export found; a wrong guess for
+  SD/CD just falls back to the old behaviour and never breaks a single-media
+  player. The SD/CD letters should be confirmed against a deck with that media.
 
 ## Hardware finding: the dbserver-client path is blocked by our player number
 

--- a/docs/design/external-metadata.md
+++ b/docs/design/external-metadata.md
@@ -97,15 +97,17 @@ framing is familiar — but the client handshake and menu-render flow are new.
   (which is built around a library track object and its deck-control features),
   so it is deferred as its own feature, not a loose end.
 
-### Known limitations (need a deck)
+### Media slots
 
-- The export-name -> slot mapping is slot-aware but best-effort. `mediadb`
-  passes `FetchExportPDB` a preferred export per slot (USB(3)->/C/ confirmed on
-  hardware, SD(2)->/B/ and CD(1)->/A/ guessed), tried before the advertised
-  MOUNT EXPORT list and the common roots. So a player with both a USB and an SD
-  no longer collapses both slots onto the first export found; a wrong guess for
-  SD/CD just falls back to the old behaviour and never breaks a single-media
-  player. The SD/CD letters should be confirmed against a deck with that media.
+- The export-name -> slot mapping is confirmed on a CDJ-2000NXS2: USB(3)->/C/,
+  SD(2)->/B/. `mediadb` passes `FetchExportPDB` the matching export per slot,
+  tried before the advertised MOUNT EXPORT list and the common roots, so a
+  player with both a USB and an SD resolves each to the right pdb instead of
+  collapsing both onto the first export found.
+- A CD (slot 1) carries no rekordbox export (the deck's MOUNT EXPORT list is
+  empty and every mount is refused), so there is nothing to fetch. We skip the
+  fetch entirely for the CD slot and fall back to the "CD · player N" source
+  label, avoiding pointless NFS churn during CD playback.
 
 ## Hardware finding: the dbserver-client path is blocked by our player number
 

--- a/mediadb/fetcher.go
+++ b/mediadb/fetcher.go
@@ -100,6 +100,24 @@ func key(player, slot uint8) string {
 	return fmt.Sprintf("%d:%d", player, slot)
 }
 
+// slotExport is the NFS export a media slot most likely lives at, tried first so
+// a player with both a USB and an SD mounted resolves each to the right pdb
+// rather than to whichever export is listed first. USB(3)->/C/ is confirmed on
+// hardware; SD(2)->/B/ and CD(1)->/A/ are best-effort (the fetch falls back to
+// the advertised export list and common roots, so a wrong guess never breaks a
+// single-media player). TrackSlot values: CD=1, SD=2, USB=3.
+func slotExport(slot uint8) string {
+	switch slot {
+	case 3:
+		return "/C/"
+	case 2:
+		return "/B/"
+	case 1:
+		return "/A/"
+	}
+	return ""
+}
+
 // Get returns metadata for a track on the given player's media, or nil when the
 // media's database isn't downloaded yet (a background fetch starts on the first
 // miss) or the track isn't in it.
@@ -195,7 +213,7 @@ func (f *Fetcher) doFetch(player, slot uint8) (*pdb.Database, string) {
 	}
 	defer c.Close()
 
-	data, export, err := c.FetchExportPDB()
+	data, export, err := c.FetchExportPDB(slotExport(slot))
 	if err != nil {
 		log.Printf("mediadb: player %d (%s) export.pdb: %v", player, ip, err)
 		return nil, ""

--- a/mediadb/fetcher.go
+++ b/mediadb/fetcher.go
@@ -100,20 +100,21 @@ func key(player, slot uint8) string {
 	return fmt.Sprintf("%d:%d", player, slot)
 }
 
-// slotExport is the NFS export a media slot most likely lives at, tried first so
-// a player with both a USB and an SD mounted resolves each to the right pdb
-// rather than to whichever export is listed first. USB(3)->/C/ is confirmed on
-// hardware; SD(2)->/B/ and CD(1)->/A/ are best-effort (the fetch falls back to
-// the advertised export list and common roots, so a wrong guess never breaks a
-// single-media player). TrackSlot values: CD=1, SD=2, USB=3.
+// slotCD is the TrackSlot value for the CD/disc slot (SD=2, USB=3). A CD carries
+// no rekordbox export, so we never fetch metadata for it.
+const slotCD = 1
+
+// slotExport is the NFS export a media slot lives at, tried first so a player
+// with both a USB and an SD mounted resolves each to the right pdb rather than
+// to whichever export is listed first. Both confirmed on a CDJ-2000NXS2:
+// USB(3)->/C/, SD(2)->/B/. The fetch still falls back to the advertised export
+// list and the common roots if a deck differs.
 func slotExport(slot uint8) string {
 	switch slot {
 	case 3:
 		return "/C/"
 	case 2:
 		return "/B/"
-	case 1:
-		return "/A/"
 	}
 	return ""
 }
@@ -199,8 +200,8 @@ func (f *Fetcher) fetch(k string, player, slot uint8) {
 }
 
 func (f *Fetcher) doFetch(player, slot uint8) (*pdb.Database, string) {
-	if f.ResolveIP == nil {
-		return nil, ""
+	if f.ResolveIP == nil || slot == slotCD {
+		return nil, "" // a CD carries no rekordbox export; don't churn NFS for it
 	}
 	ip := f.ResolveIP(player)
 	if ip == nil {

--- a/mediadb/fetcher_test.go
+++ b/mediadb/fetcher_test.go
@@ -57,6 +57,15 @@ func TestGetCacheHit(t *testing.T) {
 	}
 }
 
+func TestSlotExport(t *testing.T) {
+	cases := map[uint8]string{3: "/C/", 2: "/B/", 1: "/A/", 0: "", 9: ""}
+	for slot, want := range cases {
+		if got := slotExport(slot); got != want {
+			t.Errorf("slotExport(%d) = %q, want %q", slot, got, want)
+		}
+	}
+}
+
 func TestAnalysisCache(t *testing.T) {
 	f := NewFetcher(nil)
 	a := &Analysis{DurationMs: 180000, BPM: 128, WaveDetail: []byte{1, 2, 3, 4}}

--- a/mediadb/fetcher_test.go
+++ b/mediadb/fetcher_test.go
@@ -3,6 +3,7 @@
 package mediadb
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -58,11 +59,20 @@ func TestGetCacheHit(t *testing.T) {
 }
 
 func TestSlotExport(t *testing.T) {
-	cases := map[uint8]string{3: "/C/", 2: "/B/", 1: "/A/", 0: "", 9: ""}
+	cases := map[uint8]string{3: "/C/", 2: "/B/", 1: "", 0: "", 9: ""}
 	for slot, want := range cases {
 		if got := slotExport(slot); got != want {
 			t.Errorf("slotExport(%d) = %q, want %q", slot, got, want)
 		}
+	}
+}
+
+func TestDoFetchSkipsCD(t *testing.T) {
+	// A CD (slot 1) carries no rekordbox export; the fetch must short-circuit
+	// before touching the network even with a resolvable IP.
+	f := NewFetcher(func(uint8) net.IP { return net.IPv4(169, 254, 1, 2) })
+	if db, ex := f.doFetch(1, slotCD); db != nil || ex != "" {
+		t.Fatalf("doFetch for CD = (%v, %q), want (nil, \"\")", db, ex)
 	}
 }
 

--- a/nfs/client.go
+++ b/nfs/client.go
@@ -502,11 +502,23 @@ func (c *Client) ReadFile(export, path string) ([]byte, error) {
 // FetchExportPDB downloads the rekordbox export.pdb, trying the server's
 // advertised export list first and then common CDJ roots. It returns the bytes
 // and the export they came from.
-func (c *Client) FetchExportPDB() ([]byte, string, error) {
+// FetchExportPDB downloads the rekordbox export.pdb. preferred is the export the
+// caller believes matches the media it wants (e.g. the letter for a slot); it is
+// tried first, then the server's advertised export list, then common CDJ roots.
+// The preferred hint matters only when a player has more than one media mounted
+// (USB + SD), where every export otherwise resolves to whichever comes first.
+func (c *Client) FetchExportPDB(preferred string) ([]byte, string, error) {
 	var candidates []string
+	if preferred != "" {
+		candidates = append(candidates, preferred)
+	}
 	if exports, err := c.Exports(); err == nil {
 		log.Printf("nfs client: %s exports: %v", c.ip, exports)
-		candidates = append(candidates, exports...)
+		for _, e := range exports {
+			if !containsStr(candidates, e) {
+				candidates = append(candidates, e)
+			}
+		}
 	} else {
 		log.Printf("nfs client: %s EXPORT failed (%v); trying common roots", c.ip, err)
 	}

--- a/nfs/client_test.go
+++ b/nfs/client_test.go
@@ -82,7 +82,7 @@ func TestClientFetchExportPDB(t *testing.T) {
 
 	// The full mount -> lookup chain -> chunked read must return the file byte
 	// for byte.
-	got, ex, err := c.FetchExportPDB()
+	got, ex, err := c.FetchExportPDB("")
 	if err != nil {
 		t.Fatalf("FetchExportPDB: %v", err)
 	}


### PR DESCRIPTION
## What & why

Finishes the follow-ups from the external-track metadata work. When a deck plays a track from its own media, we download that player's rekordbox `export.pdb` over NFS to resolve the track. A player with both a USB and an SD mounted exposes two NFS exports, and the fetch returned whichever came first, so both slots resolved to the same database and one medium's tracks got the other's metadata.

`mediadb` now passes `FetchExportPDB` the export that matches the slot, tried before the advertised MOUNT EXPORT list and the common roots, so each slot resolves to its own pdb. Both mappings are confirmed on a CDJ-2000NXS2: USB (slot 3) is `/C/`, SD (slot 2) is `/B/`. A single-media player is unaffected, and a deck whose export names differ still falls back to the advertised list.

A CD (slot 1) carries no rekordbox export: the deck's MOUNT EXPORT list comes back empty and every mount is refused. There is nothing to fetch, so the fetch is skipped for the CD slot entirely rather than dialling NFS and failing four mounts every 30s during CD playback; it falls back to the "CD player N" source label, the same as before but without the churn.

## Notes

- `FetchExportPDB` gains a `preferred` argument (the slot's export, tried first). The preferred hint only matters when more than one medium is mounted; with a single medium the advertised list and roots behave as before.
- The design doc records the confirmed slot mapping and the CD behaviour, and notes that a zoom / beat-grid view for external tracks would be a dedicated inspector (the library-track detail drawer is built around a library track and its deck-control features, so it does not fit external tracks) rather than a loose end. That is left as a separate future feature.

## Verification

New tests cover the slot to export mapping and the CD short-circuit (which returns before touching the network). The existing NFS loopback test is updated for the new `FetchExportPDB` signature. `go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt -l .` are clean.

## Hardware testing

- **Tested on:** CDJ-2000NXS2. Confirmed live: a track played from the deck's SD card resolved its real metadata from the `/B/` export (slot 2: 3 tracks from `/B/`), and a track from the CD slot showed the empty export list and refused mounts, so it is now skipped and falls back to the source label. This only changes which of another player's exports we read over NFS; it does not touch the load, serve, or analysis paths, so it cannot regress the normal deck-facing flow.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
