### PR TITLE
api: write analysis back to the library row on every result path

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -164,6 +164,19 @@ func (s *Store) Set(trackID uint32, r *Result) {
 	}
 }
 
+// Remove drops the in-memory result and path mapping for a track, for use
+// when the track is deleted from the library. The on-disk cache entry is
+// deliberately kept: it is keyed by file path (derived from the audio
+// content, not track state), so re-adding the same file later reuses it
+// instead of re-analyzing. Without this, a deleted track's Result (waveform
+// blobs and all, hundreds of KB) stayed resident until restart.
+func (s *Store) Remove(trackID uint32) {
+	s.mu.Lock()
+	delete(s.results, trackID)
+	delete(s.pathMap, trackID)
+	s.mu.Unlock()
+}
+
 // Status returns a human-readable status line for the monitor UI.
 func (s *Store) Status() string {
 	s.statusMu.RLock()

--- a/api/api.go
+++ b/api/api.go
@@ -1952,6 +1952,10 @@ func (s *Server) tryQueueAnalysis(trackID uint32, filePath string) bool {
 	// here). SetPath above lets Get find the .gob now.
 	if r := s.Analysis.Get(trackID); r != nil {
 		s.queuedAnalyses.Delete(trackID)
+		// A cache hit skips the worker, so apply the worker's library-row
+		// writeback here — without this, a deleted-and-re-added track (whose
+		// cache entry survives, keyed by file path) keeps BPM/duration 0.
+		s.applyAnalysisToTrack(trackID, r)
 		return false
 	}
 	s.Analysis.IncPending()
@@ -1971,26 +1975,7 @@ func (s *Server) analysisWorker() {
 			continue
 		}
 		s.Analysis.Set(job.trackID, r)
-
-		if t := s.Library.Track(job.trackID); t != nil {
-			if t.BPM == 0 && r.BPM > 0 {
-				t.BPM = r.BPM
-			}
-			if t.Duration == 0 && r.Duration > 0 {
-				t.Duration = library.DurationSec(time.Duration(r.Duration) * time.Second)
-			}
-			if t.Key == "" && r.KeyCamelot != "" {
-				t.Key = r.KeyCamelot
-			}
-			// Estimate bitrate from file size and duration.
-			if t.Bitrate == 0 && t.FileSize > 0 && t.Duration > 0 {
-				t.Bitrate = int(t.FileSize * 8 / int64(t.Duration.Seconds()) / 1000)
-			}
-			s.Library.Save()
-		}
-		if r.Artwork != nil {
-			s.Library.Artwork.AddWithID(job.trackID, "image/jpeg", r.Artwork)
-		}
+		s.applyAnalysisToTrack(job.trackID, r)
 
 		// Update device track count.
 		if s.Device != nil {
@@ -1999,6 +1984,53 @@ func (s *Server) analysisWorker() {
 
 		s.Analysis.ClearStatus()
 		log.Printf("api: analyzed track %d: BPM=%.1f key=%s path=%s", job.trackID, r.BPM, r.KeyCamelot, job.filePath)
+	}
+}
+
+// applyAnalysisToTrack fills a library row's analysis-derived fields (BPM,
+// duration, key, bitrate, artwork) from a result. Only empty fields are
+// filled — user edits and existing values are never clobbered — and the
+// library is saved only when something actually changed, so callers can
+// invoke it on every analysis retrieval and it noops once the row is filled.
+//
+// This is the single writeback point for every api route that lands an
+// analysis result: the worker queue, the on-demand path, and a disk-cache
+// hit. Before this, only the worker wrote back, so a track deleted and
+// re-added (whose cache entry survives, keyed by file path) skipped the
+// worker and kept BPM/duration/key zeroed forever — and the web UI scales
+// the detail waveform by the row's duration, so the re-added track showed
+// no waveform at all.
+func (s *Server) applyAnalysisToTrack(trackID uint32, r *analysis.Result) {
+	if s.Library == nil || r == nil {
+		return
+	}
+	t := s.Library.Track(trackID)
+	if t == nil {
+		return
+	}
+	changed := false
+	if t.BPM == 0 && r.BPM > 0 {
+		t.BPM = r.BPM
+		changed = true
+	}
+	if t.Duration == 0 && r.Duration > 0 {
+		t.Duration = library.DurationSec(time.Duration(r.Duration) * time.Second)
+		changed = true
+	}
+	if t.Key == "" && r.KeyCamelot != "" {
+		t.Key = r.KeyCamelot
+		changed = true
+	}
+	// Estimate bitrate from file size and duration.
+	if t.Bitrate == 0 && t.FileSize > 0 && t.Duration > 0 {
+		t.Bitrate = int(t.FileSize * 8 / int64(t.Duration.Seconds()) / 1000)
+		changed = true
+	}
+	if changed {
+		s.Library.Save()
+	}
+	if r.Artwork != nil && s.Library.Artwork.Get(trackID) == nil {
+		s.Library.Artwork.AddWithID(trackID, "image/jpeg", r.Artwork)
 	}
 }
 
@@ -2050,6 +2082,7 @@ func (s *Server) getOrAnalyze(trackID uint32) *analysis.Result {
 		return nil
 	}
 	if r := s.Analysis.Get(trackID); r != nil {
+		s.applyAnalysisToTrack(trackID, r)
 		return r
 	}
 
@@ -2072,6 +2105,7 @@ func (s *Server) getOrAnalyze(trackID uint32) *analysis.Result {
 	// Analyze synchronously.
 	s.Analysis.SetPath(trackID, filePath)
 	if r := s.Analysis.Get(trackID); r != nil {
+		s.applyAnalysisToTrack(trackID, r)
 		return r // disk cache was valid after SetPath
 	}
 
@@ -2082,6 +2116,7 @@ func (s *Server) getOrAnalyze(trackID uint32) *analysis.Result {
 		return nil
 	}
 	s.Analysis.Set(trackID, r)
+	s.applyAnalysisToTrack(trackID, r)
 	log.Printf("api: analyzed track %d: BPM=%.1f key=%s path=%s", trackID, r.BPM, r.KeyCamelot, filePath)
 	return r
 }
@@ -2768,6 +2803,10 @@ func (s *Server) handleWaveformPNG(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	result := s.Analysis.Get(trackID)
+	// Heal the library row from the result (noop once filled): thumbnails are
+	// often the first thing to touch a re-added track's surviving cache entry,
+	// and the row's BPM/duration must follow for the rest of the UI to work.
+	s.applyAnalysisToTrack(trackID, result)
 	if result == nil {
 		s.tryQueueAnalysis(trackID, "")
 		w.Header().Set("Content-Type", "image/png")

--- a/api/api.go
+++ b/api/api.go
@@ -792,8 +792,16 @@ func (s *Server) handleTracks(w http.ResponseWriter, r *http.Request) {
 			if s.Cues != nil {
 				s.Cues.DeleteAllForTrack(trackID)
 			}
+			// Free the in-memory analysis entry (it holds the waveform
+			// blobs) and any stale queue marker. The on-disk analysis
+			// cache is kept on purpose: it is keyed by file path, so
+			// re-adding the same file reuses it instead of re-analyzing.
+			if s.Analysis != nil {
+				s.Analysis.Remove(trackID)
+			}
+			s.queuedAnalyses.Delete(trackID)
 			s.Library.RemoveTrack(trackID)
-			log.Printf("api: deleted track %d (library + playlists + tags + cues)", trackID)
+			log.Printf("api: deleted track %d (library + playlists + tags + cues + analysis)", trackID)
 			writeJSON(w, struct{ OK bool }{true})
 			return
 		}


### PR DESCRIPTION
## What & why

Deleting a track and re-adding the same file left the new row with BPM, duration, and key stuck at zero, and the web UI showed no waveform for it. The detail view scales its waveform canvas by the row's duration, so a zero duration draws nothing at all, and the list row shows empty BPM and key columns.

The root cause is that only the background analysis worker wrote results back to the library row. A re-added track's analysis cache entry survives deletion, since the cache is keyed by file path rather than track ID, so the add path hits the cache, returns early, skips the worker, and nothing ever fills the row. The on-demand path (used by the waveform endpoints and the RE-ANALYZE button) also lacked the writeback, so the row could never heal, no matter what the user tried.

## The fix

The worker's writeback moves into a shared helper, `applyAnalysisToTrack`, called from every api route that lands an analysis result: the worker itself, the add path's cache-hit branch, the on-demand `getOrAnalyze` path, and the waveform-PNG handler, which is usually the first thing to touch a track's cache entry after a restart.

The helper only fills empty fields, so user edits and existing values are never clobbered, and it saves the library only when a field actually changed, so calling it per request is a noop once the row is filled. This mirrors the dbserver handler, which has always done its own writeback on the CDJ load path; the api package was the only consumer missing it.

## Delete-side cleanup

Auditing the delete path for this bug turned up the mirror-image leak: deleting a track cleaned playlists, tags, cues, and the library row, but the analysis store kept its in-memory Result (waveform blobs and all, hundreds of KB per track) and path mapping until restart. `Store.Remove` now drops the in-memory entry and the stale queue marker as part of the delete cascade.

The on-disk analysis cache is deliberately kept on delete. It is keyed by file path, derived from the audio content rather than track state, so re-adding the same file reuses it instead of re-analyzing. Together with the writeback fix, a delete/re-add cycle is now instant and correct: the re-added row fills from the kept cache in the same second, with no fresh analysis run.

## Verification

Reproduced against a data dir exhibiting the bug (a re-added track with a zeroed row and a surviving cache entry): with the fix, the broken row heals on the first waveform request, and a fresh delete/re-add cycle comes back with BPM, duration, key, and working waveforms immediately. `go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt -l .` are clean.

## Hardware testing

- **Tested on:** N/A: no deck-facing change. The dbserver/CDJ load path already had its own writeback and is untouched; this fixes the api-side routes the web UI uses.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
