### PR TITLE
analysis: bump cacheVersion for the beat-grid phase improvements

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -26,7 +26,11 @@ const AnalysisRate = 44100
 // only encoder — old V1-encoded caches (saved as 17) and the older
 // experimental V2 caches (saved as 2017 behind --pwv4-v2) both invalidate
 // here, so the next run re-analyzes once and converges on a single format.
-const cacheVersion = 25
+// Bumped to 26 for the beat-grid phase improvements (windowed clarity-weighted
+// phase, gated half-beat flip, codec-aware lossless latency): the values in a
+// v25 cache are still readable but its grids predate those fixes, so one
+// re-analysis pass upgrades every library instead of only newly-added tracks.
+const cacheVersion = 26
 
 // PWV4Override and PWV5Override, when non-nil, replace every track's color
 // preview / detail waveform at serve time. Set via the --pwv4-override /


### PR DESCRIPTION
## What & why

The beat-grid work that just landed (the windowed clarity-weighted phase, the gated half-beat flip, and the codec-aware lossless latency) changes what DetectBeats produces, but it does not change the cache format: a v25 `.gob` is still structurally valid and loads fine. Without a bump, existing libraries would keep serving their old grids forever, and the improvements would only reach newly-added tracks or tracks the user manually hits RE-ANALYZE on.

Bumping cacheVersion to 26 invalidates the old entries, so every library upgrades itself with one automatic re-analysis pass on the next run. That pass is CPU-heavy but bounded, runs on the existing worker pool, and only happens once. Waveform PNG cache names embed the result's version, so the rendered thumbnails refresh along with the grids, and the analysis writeback fills only empty row fields, so BPM/key/duration values a user has edited are not clobbered by the refresh.

The comment on the constant documents the reasoning so the next format-versus-values bump decision has a precedent to point at.

## Hardware testing

- **Tested on:** N/A: no deck-facing change beyond re-analysis producing the already-merged grid improvements. The re-analysis pass itself is covered by the v0.2.0 release checklist (upgrade-path section) ahead of tagging.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
