### PR TITLE
docs: drop sudo from rekordbox-mode run commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 
 # rekordbox mode (the default) — no privileged ports needed
 run: build
-	sudo ./vynull --music-dir $(MUSIC)
+	./vynull --music-dir $(MUSIC)
 
 # CDJ-USB source mode — needs UDP 111 (see README Requirements)
 run-cdj: build

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ By default it listens on `127.0.0.1:9443`; use `--listen 0.0.0.0:9443` to reach
 it from another device on the LAN.
 
 ```bash
-sudo ./vynull --interface eth1 --mode rekordbox --web --listen 0.0.0.0:9443
+./vynull --interface eth1 --mode rekordbox --web --listen 0.0.0.0:9443
 # then open http://<this-machine>:9443/
 ```
 
@@ -173,7 +173,7 @@ else need no Python.
 Scan a music directory at startup:
 
 ```bash
-sudo ./vynull --interface eth1 --music-dir /path/to/music --lazy-analysis
+./vynull --interface eth1 --music-dir /path/to/music --lazy-analysis
 ```
 
 ### Rekordbox USB Mode
@@ -181,6 +181,7 @@ sudo ./vynull --interface eth1 --music-dir /path/to/music --lazy-analysis
 If you have an existing rekordbox-exported USB drive:
 
 ```bash
+# CDJ mode needs UDP 111 — see "Port 111 (CDJ mode only)" for sudo-free options
 sudo ./vynull --interface eth1 --music-dir /media/usb --mode cdj
 ```
 


### PR DESCRIPTION
## What & why

rekordbox mode (the default) binds only unprivileged ports: the deck queries Pioneer's non-standard portmapper on UDP 50111, and the README's own "Port 111 (CDJ mode only)" section says exactly that. But the Web UI and Directory Mode examples and the Makefile run target all started with sudo anyway, teaching every new user to run the whole app as root for nothing. The Makefile even said "no privileged ports needed" one line above the sudo. Verified against nfs/portmap.go: the privileged port 111 bind is attempted only in CDJ mode.

sudo is dropped from the two rekordbox-mode README examples and the Makefile run target. The --mode cdj example keeps sudo, since CDJ-USB sources query the standard RPC portmapper on the privileged UDP 111, and gains a comment pointing at the sudo-free options (sysctl / setcap / iptables) already documented in the Requirements section.

Documentation and Makefile only; no code changes. The matching quick-start fix on the website shipped separately in the vynull-site repo.

## Hardware testing

- **Tested on:** N/A: docs and Makefile only, no code change.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`) (n/a, no new files)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
