### PR TITLE
make: test and check targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-.PHONY: build run run-cdj generate e2e clean
+.PHONY: build test check run run-cdj generate e2e clean
 
 build:
 	go build -o vynull .
+
+test:
+	go test ./...
+
+# The full pre-release gate: build, vet, formatting, unit tests, then the
+# e2e suite (see the e2e target's requirements below).
+check:
+	go build ./...
+	go vet ./...
+	@fmt=$$(gofmt -l .); if [ -n "$$fmt" ]; then echo "gofmt needed:"; echo "$$fmt"; exit 1; fi
+	go test ./...
+	$(MAKE) e2e
 
 # rekordbox mode (the default) — no privileged ports needed
 run: build


### PR DESCRIPTION
## What & why

Two new Makefile targets. `make test` runs the unit suite. `make check` is the full pre-release gate: build, vet, a gofmt guard, the unit tests, and then the e2e suite - one command where the release ritual previously ran five.

The gofmt step is a real guard, not just a listing: plain `gofmt -l` prints offending files but exits zero, so it passes silently in a command chain. The target fails the run and names the files. Verified by mutation: a deliberately misformatted file makes `make check` exit non-zero and print the path; removing it goes back to green.

`make check` was run end to end on this branch, including the e2e suite (which still needs ffmpeg and the DJ-Link UDP ports free, as documented on the e2e target).

## Hardware testing

- **Tested on:** N/A: Makefile only, no code change.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`) (n/a, no new files)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)