### PR TITLE
web: waveform thumbnails show instantly and stop flashing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2871,10 +2871,16 @@ func (s *Server) handleWaveformPNG(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "render failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// Best-effort write to disk for next time.
+	// Best-effort write to disk for next time. Write-to-temp + rename so a
+	// concurrent request reading cachePath can never observe a partial file:
+	// lazy-loading <img> tags fan out many thumbnail requests at once, and a
+	// truncated PNG served here would be cached by the browser for a week.
 	if cachePath != "" {
 		_ = os.MkdirAll(filepath.Dir(cachePath), 0o755)
-		_ = os.WriteFile(cachePath, imgBytes, 0o644)
+		tmp := fmt.Sprintf("%s.tmp%d", cachePath, os.Getpid())
+		if err := os.WriteFile(tmp, imgBytes, 0o644); err == nil {
+			_ = os.Rename(tmp, cachePath)
+		}
 	}
 	w.Write(imgBytes)
 }

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -4057,8 +4057,27 @@ function waveThumbSrc(tid, bust) {
 }
 function updateThumbnailSrcs() {
   document.querySelectorAll('img[data-libtrack]').forEach(img => {
-    img.src = waveThumbSrc(img.getAttribute('data-libtrack'));
+    swapImgSrc(img, waveThumbSrc(img.getAttribute('data-libtrack')));
   });
+}
+
+// swapImgSrc replaces an <img> src without the black flash: setting .src
+// directly blanks the element while an uncached resource loads (exposing the
+// dark cell background — most visible on recently-added tracks whose PNG
+// isn't disk-cached at the new size yet, so the server renders live). Preload
+// through a detached Image and swap only once the bytes are in, so the old
+// frame stays up throughout. No-op when the URL is already current.
+function swapImgSrc(img, url) {
+  if (img.getAttribute('src') === url) return;
+  const pre = new Image();
+  pre.onload = () => {
+    // The row may have been re-rendered or retargeted while preloading.
+    if (document.body.contains(img)) {
+      img.src = url;
+    }
+  };
+  pre.onerror = () => {}; // keep the old frame on failure
+  pre.src = url;
 }
 // Debounced re-fetch of every visible waveform thumbnail at the new displayed
 // size — used when the row height or waveform column width changes.
@@ -5581,6 +5600,9 @@ function thumbLoaded(img) {
   const tid = img.getAttribute('data-libtrack');
   setTimeout(() => {
     if (!tid || !document.body.contains(img)) return;
+    // Direct src set on purpose: the retry chain relies on the onload cycle
+    // (src -> onload -> thumbLoaded -> next retry), and the cell is showing
+    // the 1x1 placeholder anyway, so there is no frame to preserve.
     img.src = waveThumbSrc(tid, true);
   }, delayMs);
 }

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -4048,12 +4048,28 @@ function autoFitColumns() {
 function waveThumbCSS() {
   return { w: Math.max(60, Math.round(libWaveColWidth() - 16)), h: Math.max(14, libraryRowHeight - 8) };
 }
+// trackIsAnalyzed memoizes "does this track have analysis" per allTracks
+// snapshot (the poll swaps in a fresh array whenever anything changes).
+let _analyzedMemoSrc = null, _analyzedMemo = null;
+function trackIsAnalyzed(tid) {
+  if (_analyzedMemoSrc !== allTracks) {
+    _analyzedMemo = new Set((allTracks || []).filter(t => t.bpm > 0).map(t => t.id));
+    _analyzedMemoSrc = allTracks;
+  }
+  return _analyzedMemo.has(Number(tid));
+}
 function waveThumbSrc(tid, bust) {
   const c = waveThumbCSS();
   const dpr = Math.min(3, window.devicePixelRatio || 1);
   const w = Math.min(2400, Math.round(c.w * dpr));
   const h = Math.min(240, Math.round(c.h * dpr));
-  return `/api/analysis/waveform-png/${tid}?type=detail&color=${effectiveWaveColor()}&overview=${overviewType()}&w=${w}&h=${h}` + (bust ? `&_=${Date.now()}` : '');
+  // &a=1 once the track is analyzed: the URL must CHANGE when analysis
+  // lands, or re-created <img> elements keep resurrecting the placeholder
+  // from the browser's per-document image cache (no-store notwithstanding)
+  // for as long as the table keeps rebuilding — which during a batch
+  // analysis is every poll tick.
+  const a = trackIsAnalyzed(tid) ? '&a=1' : '';
+  return `/api/analysis/waveform-png/${tid}?type=detail&color=${effectiveWaveColor()}&overview=${overviewType()}&w=${w}&h=${h}${a}` + (bust ? `&_=${Date.now()}` : '');
 }
 function updateThumbnailSrcs() {
   document.querySelectorAll('img[data-libtrack]').forEach(img => {

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -5602,19 +5602,32 @@ function thumbLoaded(img) {
     // hits the server's disk-cached PNG, so it is one cheap fetch that
     // makes every later re-render instant.
     const tid = img.getAttribute('data-libtrack');
-    if (tid && img.src.includes('&_=')) {
+    if (tid && /[?&]_=/.test(img.src)) {
       swapImgSrc(img, waveThumbSrc(tid));
     }
     return;
   }
+  scheduleThumbRetry(img);
+}
+
+// scheduleThumbRetry keeps a pending thumbnail's self-heal alive. Analysis
+// can sit behind a LONG queue (bulk add, or the one-time cacheVersion
+// re-analysis pass), so a short fixed retry budget silently gave up before
+// the track's turn came — and the thumbnail then never appeared without a
+// page refresh. Quick retries for the first minute (analysis normally wins
+// that race), then back off to ~30-45s for up to roughly two hours; the
+// placeholder responses being retried are no-store and cost the server
+// almost nothing.
+function scheduleThumbRetry(img) {
   const tries = parseInt(img.dataset.retries || '0', 10);
-  if (tries >= 60) return;            // ~6 minutes of retries, then give up
+  if (tries >= 250) return; // ~2h with backoff — permanently-failed analysis stops here
   img.dataset.retries = String(tries + 1);
-  const delayMs = 5000 + Math.floor(Math.random() * 3000);
+  const base = tries < 12 ? 5000 : 30000;
+  const delayMs = base + Math.floor(Math.random() * base * 0.6);
   const tid = img.getAttribute('data-libtrack');
   setTimeout(() => {
     if (!tid || !document.body.contains(img)) return;
-    // Direct src set on purpose: the retry chain relies on the onload cycle
+    // Direct src set on purpose: the retry chain rides the onload cycle
     // (src -> onload -> thumbLoaded -> next retry), and the cell is showing
     // the 1x1 placeholder anyway, so there is no frame to preserve.
     img.src = waveThumbSrc(tid, true);
@@ -5650,7 +5663,7 @@ const LIBRARY_COLUMNS = [
     cell: t => artHTML(t, 'lib-art', 'lib-art empty', '') },
   { key: 'waveform', label: 'WV',     default: true,  thClass: '',    tdClass: 'wave-cell',
     sortable: false,
-    cell: t => `<div class="wave-thumb"><img class="loading" data-libtrack="${t.id}" alt="" loading="lazy" src="${waveThumbSrc(t.id)}" onload="thumbLoaded(this)">${cueMarkerOverlay(t.id, t.duration)}</div>` },
+    cell: t => `<div class="wave-thumb"><img class="loading" data-libtrack="${t.id}" alt="" loading="lazy" src="${waveThumbSrc(t.id)}" onload="thumbLoaded(this)" onerror="scheduleThumbRetry(this)">${cueMarkerOverlay(t.id, t.duration)}</div>` },
   { key: 'id',       label: 'ID',     default: true,  thClass: 'num', tdClass: 'num',
     sort: t => t.id,
     cell: t => String(t.id).padStart(4, '0') },

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -5592,7 +5592,21 @@ function fmtPath(p) {
 // out so we don't stampede the server after a fresh page load.
 function thumbLoaded(img) {
   img.classList.replace('loading', 'loaded');
-  if (img.naturalWidth !== 1) return; // real waveform, done
+  if (img.naturalWidth !== 1) {
+    // Real waveform. If it arrived via a cache-busted self-heal URL, swap
+    // back to the natural URL (preload keeps the frame up): the natural URL
+    // was last fetched when it returned the no-store placeholder, so the
+    // browser has nothing cached under it — without this, the next table
+    // re-render (view switch) starts cache-cold and the freshly-analyzed
+    // track sits blank again waiting on a full round-trip. The swap request
+    // hits the server's disk-cached PNG, so it is one cheap fetch that
+    // makes every later re-render instant.
+    const tid = img.getAttribute('data-libtrack');
+    if (tid && img.src.includes('&_=')) {
+      swapImgSrc(img, waveThumbSrc(tid));
+    }
+    return;
+  }
   const tries = parseInt(img.dataset.retries || '0', 10);
   if (tries >= 60) return;            // ~6 minutes of retries, then give up
   img.dataset.retries = String(tries + 1);


### PR DESCRIPTION
## What & why

Four commits chasing one user-visible bug to its root: newly-added tracks' waveform thumbnails flashed black on view switches, and under a busy analysis queue never appeared at all until a page refresh. Found and fixed during the v0.3.0 release-test pass.

The root cause (last commit, and the one that actually matters): the browser's per-document image cache satisfies a re-created img with the bytes it already holds for that URL - the pre-analysis placeholder - no-store notwithstanding. During a batch analysis the library rev changes every poll tick and the table fully rebuilds each time, so every rebuilt row resurrected the placeholder; nothing racing the rebuilds could win. Measured against the real app: the waveform appeared 27 seconds after analysis completed (whenever the retry cadence happened to land after the churn stopped), and an explicit post-analysis kick only got that to 21 seconds because the next rebuild destroyed it. waveThumbSrc now appends a marker (&a=1) once the track has analysis, memoized per tracks snapshot, so the URL itself changes the moment the poll sees the BPM land - a rebuilt row can no longer collide with the cached placeholder. Measured after the fix: waveform visible in the same poll tick as the BPM, zero heal latency, all rows intact across view switches.

The three earlier commits fix real adjacent bugs the investigation surfaced, each verified in a browser harness against the extracted shipped functions:

- Rewriting an img src directly blanks the element while an uncached resource loads, exposing the dark cell background - the black flash on view switches and column resizes, most visible on recently-added tracks whose PNG was not disk-cached at the new size. Src swaps now preload through a detached Image and swap only once the bytes are in; the old frame stays up throughout. On the server side, the rendered-PNG disk cache was written with a plain WriteFile racing concurrent reads of the same path, so a reader could get a truncated PNG that the 7-day Cache-Control would then pin in the browser; the cache write is now write-to-temp + rename.
- A thumbnail healed via the cache-busted retry URL left the browser cache cold under the natural URL every future render uses; healed thumbnails now re-point at the natural URL, priming the cache with one cheap request.
- The placeholder self-heal retried for a fixed ~6 minutes and then gave up silently - with analysis behind a long queue (bulk add, or the one-time cacheVersion re-analysis pass) the budget exhausted before the track's turn came, and the thumbnail then never appeared without a refresh. A failed fetch (server restart mid-request) killed the chain the same way. The retry now backs off (quick for the first minute, then ~30-45s for up to two hours) and an onerror handler reschedules, so neither long queues nor restarts strand it. The chain remains the fallback for lazy-analysis mode and fetch errors; the URL marker handles the common path.

Verified end to end by driving the real binary with a synthesized 12-track batch in a headless browser, measuring the time from BPM landing on the row to the waveform rendering: 27s before, 0s after, with view switches and a mid-batch tab-away/tab-back leaving every row intact.

## Hardware testing

- **Tested on:** N/A: web UI + one server-side cache-write fix; no deck-facing change. The waveform PNGs decks never see (they get PWV blobs over dbserver) are unaffected in content, only in cache-write atomicity.

## Checklist

- [x] `go build ./...`, `go vet ./...`, and `go test ./...` pass
- [x] `gofmt -l .` is clean
- [x] New source files carry an SPDX header (`GPL-3.0-or-later`) (n/a, no new files)
- [x] Tested on real hardware (deck + firmware noted above), **or** this change doesn't affect deck behaviour
- [x] I agree my contribution is licensed under the project's [GPLv3](../LICENSE)
